### PR TITLE
OPML Export isn't conforming to spec and breaks consumers

### DIFF
--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -19,7 +19,7 @@
 """OPML importer and exporter (based on gPodder's "opml" module)
 
 This module contains helper classes to import subscriptions from OPML files on
-the web and to export a list of podcast objects to valid OPML 1.1 files.
+the web and to export a list of podcast objects to valid OPML 2.0 files.
 """
 
 import os
@@ -72,7 +72,7 @@ class Importer(object):
 class Exporter(object):
     """
     Helper class to export a list of channel objects to a local file in OPML
-    1.1 format. See www.opml.org for the OPML specification.
+    2.0 format. See www.opml.org for the OPML specification.
     """
 
     def __init__(self, title='my.gpodder.org Subscriptions'):

--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -121,7 +121,8 @@ class Exporter(object):
 
             outline = doc.createElement('outline')
             outline.setAttribute('title', title or '')
-            outline.setAttribute('text', description or '')
+            outline.setAttribute('description', description or '')
+            outline.setAttribute('text', title or description)
             outline.setAttribute('xmlUrl', url)
             outline.setAttribute('type', 'rss')
             return outline

--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -105,21 +105,23 @@ class Exporter(object):
         def create_outline(channel):
             from mygpo.subscriptions.models import SubscribedPodcast
             from mygpo.podcasts.models import PodcastGroup
+
+            outline = doc.createElement('outline')
+
             if isinstance(channel, SubscribedPodcast):
                 title = channel.podcast.title
                 description = channel.podcast.description
                 url = channel.ref_url
             elif isinstance(channel, PodcastGroup):
                 title = channel.title
-                podcast = channel.podcast_set.first()
-                description = podcast.description
-                url = podcast.url
+                url = channel.podcast_set.first().url
+                for subchannel in channel.podcast_set.all():
+                    outline.appendChild(create_outline(subchannel)
             else:
                 title = channel.title
                 description = channel.description
                 url = channel.url
 
-            outline = doc.createElement('outline')
             outline.setAttribute('title', title or '')
             outline.setAttribute('description', description or '')
             outline.setAttribute('text', title or description)


### PR DESCRIPTION
The OPML files gpodder.net is emitting aren't conforming to the [OPML 2.0 spec](http://dev.opml.org/spec2.html#subscriptionLists):

> For outline elements whose type is rss, the text attribute should initially be the top-level title element in the feed being pointed to, however since it is user-editable, processors should not depend on it always containing the title of the feed.

The relevant attributes are text, title, and description. The current implementation is exporting podcast descriptions as the text attribute, which according to spec should default to the top level title. There is an optional description attribute in spec that this information should go in, and since text is not optional it should never be empty.

There are three commits here. One just cleans up comments in this file that are still referring to OPML 1.1. 

The second fixes exporting so that the podcast title is in both the required text and optional title attribute. 

The third one is just what I presume is the intent here - I read up on PodcastGroups, but could not find one to actually test this on, but my intuition is that they should also be parent to their children podcasts when exported. If I'm wrong just discard that commit, I just thought it looked wrong (it is inferring its podcast info from just its first member podcast and ignoring the rest atm).
