### PR TITLE
Update to Django 1.11

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ help:
 	@echo 'make clean           clean up files'
 
 test:
-	envdir envs/dev/ coverage run ./manage.py test
+	envdir envs/dev/ python -Wd -m coverage run ./manage.py test
 	coverage report
 
 update-po:

--- a/mygpo/administration/views.py
+++ b/mygpo/administration/views.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import django
 from django.shortcuts import render
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.cache import cache
 from django.http import HttpResponseRedirect
 from django.template.loader import render_to_string

--- a/mygpo/api/advanced/__init__.py
+++ b/mygpo/api/advanced/__init__.py
@@ -84,7 +84,8 @@ def episodes(request, username, version=1):
         try:
             update_urls = update_episodes(request.user, actions, now, ua_string)
         except ValidationError as e:
-            logger.warn('Validation Error while uploading episode actions for user %s: %s', username, str(e))
+            logger.warning('Validation Error while uploading episode actions '
+                'for user %s: %s', username, str(e))
             return HttpResponseBadRequest(str(e))
 
         except InvalidEpisodeActionAttributes as e:

--- a/mygpo/api/advanced/directory.py
+++ b/mygpo/api/advanced/directory.py
@@ -1,5 +1,5 @@
 from django.http import Http404
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.sites.requests import RequestSite
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.cache import cache_page

--- a/mygpo/api/advanced/lists.py
+++ b/mygpo/api/advanced/lists.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from django.http import HttpResponse, HttpResponseBadRequest, \
      HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.sites.requests import RequestSite
 from django.contrib.auth import get_user_model
 from django.utils.text import slugify

--- a/mygpo/api/tests.py
+++ b/mygpo/api/tests.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 
 from django.test.client import Client
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 
 from mygpo.podcasts.models import Podcast, Episode

--- a/mygpo/categories/migrations/0001_initial_merged.py
+++ b/mygpo/categories/migrations/0001_initial_merged.py
@@ -46,8 +46,14 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField(
                     auto_now=True,
                     db_index=True)),
-                ('category', models.ForeignKey(to='categories.Category')),
-                ('podcast', models.ForeignKey(to='podcasts.Podcast')),
+                ('category', models.ForeignKey(
+                    to='categories.Category',
+                    on_delete=models.CASCADE,
+                )),
+                ('podcast', models.ForeignKey(
+                    to='podcasts.Podcast',
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },
@@ -64,7 +70,9 @@ class Migration(migrations.Migration):
                 ('tag', models.SlugField(unique=True)),
                 ('category', models.ForeignKey(
                     related_name='tags',
-                    to='categories.Category')),
+                    to='categories.Category',
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },
@@ -102,7 +110,9 @@ class Migration(migrations.Migration):
             name='category',
             field=models.ForeignKey(
                 related_name='entries',
-                to='categories.Category'),
+                to='categories.Category',
+                on_delete=models.CASCADE,
+            ),
         ),
         migrations.AlterField(
             model_name='categoryentry',

--- a/mygpo/chapters/migrations/0001_initial.py
+++ b/mygpo/chapters/migrations/0001_initial.py
@@ -23,8 +23,14 @@ class Migration(migrations.Migration):
                 ('end', models.IntegerField()),
                 ('label', models.CharField(max_length=100)),
                 ('advertisement', models.BooleanField(default=False)),
-                ('episode', models.ForeignKey(to='podcasts.Episode')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('episode', models.ForeignKey(
+                    to='podcasts.Episode',
+                    on_delete=models.CASCADE,
+                )),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
                 'abstract': False,

--- a/mygpo/directory/migrations/0001_initial.py
+++ b/mygpo/directory/migrations/0001_initial.py
@@ -18,7 +18,10 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('order', models.PositiveSmallIntegerField()),
-                ('podcast', models.ForeignKey(to='podcasts.Podcast')),
+                ('podcast', models.ForeignKey(
+                    to='podcasts.Podcast',
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
                 'ordering': ['order'],

--- a/mygpo/directory/models.py
+++ b/mygpo/directory/models.py
@@ -18,7 +18,7 @@ class ExamplePodcastsManager(models.Manager):
 class ExamplePodcast(UpdateInfoModel, OrderedModel):
     """ Example podcasts returned by the API """
 
-    podcast = models.ForeignKey(Podcast)
+    podcast = models.ForeignKey(Podcast, on_delete=models.CASCADE)
 
     objects = ExamplePodcastsManager()
 

--- a/mygpo/directory/views.py
+++ b/mygpo/directory/views.py
@@ -5,7 +5,7 @@ from math import ceil
 from collections import Counter
 
 from django.http import HttpResponseNotFound, Http404, HttpResponseRedirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.shortcuts import render
 from django.db.models import Count

--- a/mygpo/episodestates/migrations/0001_initial.py
+++ b/mygpo/episodestates/migrations/0001_initial.py
@@ -19,8 +19,14 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('action', models.CharField(max_length=8, choices=[('download', 'downloaded'), ('play', 'played'), ('delete', 'deleted'), ('new', 'marked as new'), ('flattr', "flattr'd")])),
                 ('timestamp', models.DateTimeField()),
-                ('episode', models.ForeignKey(to='podcasts.Episode')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('episode', models.ForeignKey(
+                    to='podcasts.Episode',
+                    on_delete=models.CASCADE,
+                )),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/favorites/migrations/0001_initial.py
+++ b/mygpo/favorites/migrations/0001_initial.py
@@ -21,7 +21,10 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('episode', models.ForeignKey(to='podcasts.Episode', on_delete=django.db.models.deletion.PROTECT)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
                 'abstract': False,

--- a/mygpo/flattr.py
+++ b/mygpo/flattr.py
@@ -11,7 +11,7 @@ import urllib.parse
 from collections import namedtuple
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from mygpo.users.settings import FLATTR_TOKEN, FLATTR_USERNAME
 from mygpo import utils

--- a/mygpo/history/migrations/0001_initial.py
+++ b/mygpo/history/migrations/0001_initial.py
@@ -20,9 +20,18 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('timestamp', models.DateTimeField()),
                 ('action', models.CharField(max_length=11, choices=[('subscribe', 'subscribed'), ('unsubscribe', 'unsubscribed')])),
-                ('client', models.ForeignKey(to='users.Client')),
-                ('podcast', models.ForeignKey(to='podcasts.Podcast')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('client', models.ForeignKey(
+                    to='users.Client',
+                    on_delete=models.CASCADE,
+                )),
+                ('podcast', models.ForeignKey(
+                    to='podcasts.Podcast',
+                    on_delete=models.CASCADE,
+                )),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
                 'ordering': ['timestamp'],

--- a/mygpo/history/migrations/0003_historyentry.py
+++ b/mygpo/history/migrations/0003_historyentry.py
@@ -23,6 +23,10 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='historyentry',
             name='client',
-            field=models.ForeignKey(to='users.Client', null=True),
+            field=models.ForeignKey(
+                to='users.Client',
+                null=True,
+                on_delete=models.CASCADE,
+            ),
         ),
     ]

--- a/mygpo/history/migrations/0004_historyentry_episode.py
+++ b/mygpo/history/migrations/0004_historyentry_episode.py
@@ -14,7 +14,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='historyentry',
             name='episode',
-            field=models.ForeignKey(to='podcasts.Episode', null=True),
+            field=models.ForeignKey(
+                to='podcasts.Episode',
+                null=True,
+                on_delete=models.CASCADE,
+            ),
             preserve_default=True,
         ),
     ]

--- a/mygpo/history/migrations/0005_episodehistoryentry.py
+++ b/mygpo/history/migrations/0005_episodehistoryentry.py
@@ -27,9 +27,20 @@ class Migration(migrations.Migration):
                 ('started', models.IntegerField(null=True)),
                 ('stopped', models.IntegerField(null=True)),
                 ('total', models.IntegerField(null=True)),
-                ('client', models.ForeignKey(to='users.Client', null=True)),
-                ('episode', models.ForeignKey(to='podcasts.Episode', null=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('client', models.ForeignKey(
+                    to='users.Client',
+                    null=True,
+                    on_delete=models.CASCADE,
+                )),
+                ('episode', models.ForeignKey(
+                    to='podcasts.Episode',
+                    null=True,
+                    on_delete=models.CASCADE,
+                )),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
                 'ordering': ['-timestamp'],

--- a/mygpo/history/migrations/0009_blank_fields.py
+++ b/mygpo/history/migrations/0009_blank_fields.py
@@ -14,7 +14,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='episodehistoryentry',
             name='client',
-            field=models.ForeignKey(blank=True, to='users.Client', null=True),
+            field=models.ForeignKey(
+                blank=True,
+                to='users.Client',
+                null=True,
+                on_delete=models.CASCADE,
+            ),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/mygpo/podcastlists/migrations/0001_initial.py
+++ b/mygpo/podcastlists/migrations/0001_initial.py
@@ -25,7 +25,10 @@ class Migration(migrations.Migration):
                 ('slug', models.SlugField(max_length=128)),
                 ('created', models.DateTimeField()),
                 ('modified', models.DateTimeField()),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },
@@ -45,10 +48,12 @@ class Migration(migrations.Migration):
                 ('object_id', models.UUIDField(max_length=32)),
                 ('content_type', models.ForeignKey(
                     to='contenttypes.ContentType',
-                    on_delete=django.db.models.deletion.PROTECT)),
+                    on_delete=django.db.models.deletion.CASCADE)),
                 ('podcastlist', models.ForeignKey(
                     related_name='entries',
-                    to='podcastlists.PodcastList')),
+                    to='podcastlists.PodcastList',
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/podcastlists/models.py
+++ b/mygpo/podcastlists/models.py
@@ -78,7 +78,7 @@ class PodcastListEntry(UpdateInfoModel, OrderedModel):
                                    )
 
     # the object (Podcast or PodcastGroup) that is in the list
-    content_type = models.ForeignKey(ContentType, on_delete=models.PROTECT)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.UUIDField()
     content_object = GenericForeignKey('content_type', 'object_id')
 

--- a/mygpo/podcastlists/models.py
+++ b/mygpo/podcastlists/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey

--- a/mygpo/podcastlists/tests.py
+++ b/mygpo/podcastlists/tests.py
@@ -1,6 +1,6 @@
 
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 from django.test import TestCase
 

--- a/mygpo/podcastlists/views.py
+++ b/mygpo/podcastlists/views.py
@@ -2,7 +2,7 @@ import uuid
 from functools import wraps
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponseForbidden
 from django.shortcuts import render, get_object_or_404
 from django.utils.text import slugify

--- a/mygpo/podcasts/migrations/0001_initial.py
+++ b/mygpo/podcasts/migrations/0001_initial.py
@@ -37,7 +37,9 @@ class Migration(migrations.Migration):
                 ('uuid', models.UUIDField(unique=True, max_length=32)),
                 ('content_type', models.ForeignKey(
                     to='contenttypes.ContentType',
-                    to_field='id')),
+                    to_field='id',
+                    on_delete=models.PROTECT,
+                )),
                 ('object_id', models.UUIDField(max_length=32)),
             ],
             options={
@@ -57,7 +59,9 @@ class Migration(migrations.Migration):
                 ('slug', models.SlugField()),
                 ('content_type', models.ForeignKey(
                     to='contenttypes.ContentType',
-                    to_field='id')),
+                    to_field='id',
+                    on_delete=models.PROTECT,
+                )),
                 ('object_id', models.UUIDField(max_length=32)),
             ],
             options={
@@ -81,7 +85,9 @@ class Migration(migrations.Migration):
                     choices=[(1, 'Feed'), (2, 'delicious'), (4, 'User')])),
                 ('content_type', models.ForeignKey(
                     to='contenttypes.ContentType',
-                    to_field='id')),
+                    to_field='id',
+                    on_delete=models.PROTECT,
+                )),
                 ('object_id', models.UUIDField(max_length=32)),
             ],
             options={
@@ -104,7 +110,9 @@ class Migration(migrations.Migration):
                 ('url', models.URLField(max_length=1000)),
                 ('content_type', models.ForeignKey(
                     to='contenttypes.ContentType',
-                    to_field='id')),
+                    to_field='id',
+                    on_delete=models.PROTECT,
+                )),
                 ('object_id', models.UUIDField(max_length=32)),
             ],
             options={
@@ -142,7 +150,9 @@ class Migration(migrations.Migration):
                 ('group', models.ForeignKey(
                     to='podcasts.PodcastGroup',
                     to_field='id',
-                    null=True)),
+                    null=True,
+                    on_delete=models.PROTECT,
+                )),
                 ('group_member_name', models.CharField(
                     max_length=30,
                     null=True)),
@@ -190,7 +200,11 @@ class Migration(migrations.Migration):
                 ('filesize', models.PositiveIntegerField(null=True)),
                 ('mimetypes', models.CharField(max_length=50)),
                 ('listeners', models.PositiveIntegerField(null=True)),
-                ('podcast', models.ForeignKey(to='podcasts.Podcast', to_field='id')),
+                ('podcast', models.ForeignKey(
+                    to='podcasts.Podcast',
+                    to_field='id',
+                    on_delete=models.PROTECT,
+                )),
             ],
             options={
                 'abstract': False,

--- a/mygpo/podcasts/migrations/0023_auto_20140729_1711.py
+++ b/mygpo/podcasts/migrations/0023_auto_20140729_1711.py
@@ -16,7 +16,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='tag',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(
+                to=settings.AUTH_USER_MODEL,
+                null=True,
+                on_delete=models.CASCADE,
+            ),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/mygpo/podcasts/views/podcast.py
+++ b/mygpo/podcasts/views/podcast.py
@@ -1,7 +1,7 @@
 from functools import wraps, partial
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseBadRequest, HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required

--- a/mygpo/publisher/migrations/0001_initial.py
+++ b/mygpo/publisher/migrations/0001_initial.py
@@ -17,8 +17,14 @@ class Migration(migrations.Migration):
             name='PublishedPodcast',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('podcast', models.ForeignKey(to='podcasts.Podcast')),
-                ('publisher', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('podcast', models.ForeignKey(
+                    to='podcasts.Podcast',
+                    on_delete=models.CASCADE,
+                )),
+                ('publisher', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/publisher/templatetags/pcharts.py
+++ b/mygpo/publisher/templatetags/pcharts.py
@@ -4,6 +4,7 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 @register.filter
+@mark_safe
 def bar_chart(parts):
 
     maxv = max([ int(x['y']) for x in parts ])
@@ -24,6 +25,4 @@ def bar_chart(parts):
         'chxr=1,0,%d' % maxv,  # labeling for axis 1 (y) from 0 to max
         ]
 
-    s = '<img src="//chart.apis.google.com/chart?%s" />' % '&'.join(parts)
-
-    return mark_safe(s)
+    return '<img src="//chart.apis.google.com/chart?%s" />' % '&'.join(parts)

--- a/mygpo/publisher/views.py
+++ b/mygpo/publisher/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse, HttpResponseRedirect, \
 from django.core.cache import cache
 from django.views.decorators.cache import never_cache, cache_control
 from django.views.decorators.vary import vary_on_cookie
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.contrib import messages
 from django.contrib.auth import get_user_model

--- a/mygpo/pubsub/utils.py
+++ b/mygpo/pubsub/utils.py
@@ -8,7 +8,7 @@ import urllib.request, urllib.parse, urllib.error
 import urllib.request, urllib.error, urllib.parse
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from mygpo.utils import random_token
 from mygpo.pubsub.models import HubSubscription, SubscriptionError

--- a/mygpo/share/views.py
+++ b/mygpo/share/views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.contrib.sites.requests import RequestSite

--- a/mygpo/subscriptions/migrations/0001_initial.py
+++ b/mygpo/subscriptions/migrations/0001_initial.py
@@ -23,7 +23,10 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('podcast', models.ForeignKey(to='podcasts.Podcast', on_delete=django.db.models.deletion.PROTECT)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
                 'abstract': False,
@@ -38,9 +41,15 @@ class Migration(migrations.Migration):
                 ('ref_url', models.URLField(max_length=2048)),
                 ('created', models.DateTimeField()),
                 ('modified', models.DateTimeField()),
-                ('client', models.ForeignKey(to='users.Client')),
+                ('client', models.ForeignKey(
+                    to='users.Client',
+                    on_delete=models.CASCADE,
+                )),
                 ('podcast', models.ForeignKey(to='podcasts.Podcast', on_delete=django.db.models.deletion.PROTECT)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/subscriptions/tests.py
+++ b/mygpo/subscriptions/tests.py
@@ -40,15 +40,15 @@ class TestSubscribe(TestCase):
         ))
 
         # ensure only one client is changed
-        self.assertEquals(len(changed_clients), 1)
-        self.assertEquals(changed_clients[0], self.client)
+        self.assertEqual(len(changed_clients), 1)
+        self.assertEqual(changed_clients[0], self.client)
 
         # ensure exactly one subscription has been created
         subscriptions = models.Subscription.objects.filter(
             podcast=self.podcast,
             user=self.user
         )
-        self.assertEquals(subscriptions.count(), 1)
+        self.assertEqual(subscriptions.count(), 1)
         subscriptions[0].delete()
 
     def tearDown(self):

--- a/mygpo/subscriptions/views.py
+++ b/mygpo/subscriptions/views.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.requests import RequestSite
 from django.shortcuts import render, get_object_or_404

--- a/mygpo/suggestions/migrations/0001_initial.py
+++ b/mygpo/suggestions/migrations/0001_initial.py
@@ -22,7 +22,10 @@ class Migration(migrations.Migration):
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('deleted', models.BooleanField(default=False)),
                 ('podcast', models.ForeignKey(to='podcasts.Podcast', on_delete=django.db.models.deletion.PROTECT)),
-                ('suggested_to', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('suggested_to', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/suggestions/views.py
+++ b/mygpo/suggestions/views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render

--- a/mygpo/test.py
+++ b/mygpo/test.py
@@ -1,7 +1,7 @@
 import os.path
 import base64
 
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.contrib.auth.models import AnonymousUser
 from django.test.client import RequestFactory
 from django.contrib.auth import get_user_model

--- a/mygpo/userfeeds/feeds.py
+++ b/mygpo/userfeeds/feeds.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from mygpo.favorites.models import FavoriteEpisode
 

--- a/mygpo/users/migrations/0001_initial.py
+++ b/mygpo/users/migrations/0001_initial.py
@@ -34,7 +34,10 @@ class Migration(migrations.Migration):
                     max_length=32,
                     null=True)),
                 ('userpage_token', models.CharField(max_length=32, null=True)),
-                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
                 ('uuid', models.UUIDField(unique=True, max_length=32)),
             ],
             options={

--- a/mygpo/users/migrations/0002_auto_20140718_1457.py
+++ b/mygpo/users/migrations/0002_auto_20140718_1457.py
@@ -36,7 +36,10 @@ class Migration(migrations.Migration):
                         ('other', 'Other')])),
                 ('deleted', models.BooleanField(default=False)),
                 ('user_agent', models.CharField(max_length=300)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/users/migrations/0004_auto_20140718_1655.py
+++ b/mygpo/users/migrations/0004_auto_20140718_1655.py
@@ -17,7 +17,10 @@ class Migration(migrations.Migration):
             name='SyncGroup',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },
@@ -26,7 +29,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='client',
             name='sync_group',
-            field=models.ForeignKey(to='users.SyncGroup', null=True),
+            field=models.ForeignKey(
+                to='users.SyncGroup',
+                null=True,
+                on_delete=models.CASCADE,
+            ),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/mygpo/users/migrations/0010_user_profile_related.py
+++ b/mygpo/users/migrations/0010_user_profile_related.py
@@ -15,6 +15,10 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='userprofile',
             name='user',
-            field=models.OneToOneField(related_name='profile', to=settings.AUTH_USER_MODEL),
+            field=models.OneToOneField(
+                related_name='profile',
+                to=settings.AUTH_USER_MODEL,
+                on_delete=models.CASCADE,
+            ),
         ),
     ]

--- a/mygpo/users/tests.py
+++ b/mygpo/users/tests.py
@@ -2,7 +2,7 @@ import uuid
 import unittest
 from collections import Counter
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client as TestClient
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/mygpo/users/urls.py
+++ b/mygpo/users/urls.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.contrib.auth.views import logout
+from django.contrib.auth.views import LogoutView
 from django.views.generic.base import TemplateView
 
 from .views import registration, settings, device, user
@@ -148,7 +148,7 @@ urlpatterns = [
         name='login-google-callback'),
 
     url(r'^logout/$',
-        logout,
+        LogoutView.as_view(),
         kwargs={'next_page': '/'},
         name='logout'),
 

--- a/mygpo/users/views/device.py
+++ b/mygpo/users/views/device.py
@@ -4,7 +4,7 @@ from xml.parsers.expat import ExpatError
 
 from django.db import transaction, IntegrityError
 from django.shortcuts import render
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, \
         HttpResponseNotFound

--- a/mygpo/users/views/registration.py
+++ b/mygpo/users/views/registration.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseRedirect
 from django.views.generic.edit import FormView
 from django.utils.translation import ugettext as _
 from django.template.loader import render_to_string
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.views.generic import TemplateView
 from django.views import View
 from django.contrib import messages

--- a/mygpo/users/views/settings.py
+++ b/mygpo/users/views/settings.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.contrib.auth import logout
 from django.contrib import messages

--- a/mygpo/users/views/user.py
+++ b/mygpo/users/views/user.py
@@ -14,7 +14,7 @@ from django.template.loader import render_to_string
 from django.views import View
 from django.views.generic import TemplateView
 from django.utils.decorators import method_decorator
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.http import is_safe_url
 
 import requests

--- a/mygpo/usersettings/migrations/0001_initial.py
+++ b/mygpo/usersettings/migrations/0001_initial.py
@@ -29,8 +29,13 @@ class Migration(migrations.Migration):
                 ('content_type', models.ForeignKey(
                     blank=True,
                     to='contenttypes.ContentType',
-                    null=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                    null=True,
+                    on_delete=models.PROTECT,
+                )),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/usersettings/models.py
+++ b/mygpo/usersettings/models.py
@@ -65,7 +65,12 @@ class UserSettings(models.Model):
                              on_delete=models.CASCADE)
 
     # see https://docs.djangoproject.com/en/1.6/ref/contrib/contenttypes/#generic-relations
-    content_type = models.ForeignKey(ContentType, null=True, blank=True)
+    content_type = models.ForeignKey(
+        ContentType,
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+    )
     object_id = models.UUIDField(null=True, blank=True)
     content_object = GenericForeignKey('content_type', 'object_id')
 

--- a/mygpo/usersettings/tests.py
+++ b/mygpo/usersettings/tests.py
@@ -4,7 +4,7 @@ import uuid
 import urllib.request, urllib.parse, urllib.error
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client as TestClient
 from django.test import TestCase
 

--- a/mygpo/utils.py
+++ b/mygpo/utils.py
@@ -21,7 +21,7 @@ import shlex
 
 from django.db import transaction, IntegrityError
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 import logging
 logger = logging.getLogger(__name__)

--- a/mygpo/votes/migrations/0001_initial.py
+++ b/mygpo/votes/migrations/0001_initial.py
@@ -28,7 +28,10 @@ class Migration(migrations.Migration):
                 ('content_type', models.ForeignKey(
                     to='contenttypes.ContentType',
                     on_delete=django.db.models.deletion.PROTECT)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(
+                    to=settings.AUTH_USER_MODEL,
+                    on_delete=models.CASCADE,
+                )),
             ],
             options={
             },

--- a/mygpo/web/auth.py
+++ b/mygpo/web/auth.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.contrib.sites.requests import RequestSite
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 class EmailAuthenticationBackend(ModelBackend):

--- a/mygpo/web/logo.py
+++ b/mygpo/web/logo.py
@@ -8,7 +8,7 @@ import struct
 
 from PIL import Image, ImageDraw
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseNotFound
 from django.views import View

--- a/mygpo/web/templatetags/charts.py
+++ b/mygpo/web/templatetags/charts.py
@@ -40,6 +40,7 @@ def vertical_bar(value, max_value, display=None):
 
 
 @register.filter
+@mark_safe
 def timeline(data):
     s = '<script type="text/javascript" src="//www.google.com/jsapi"></script>\n'
     s += '<script type="text/javascript">\n'
@@ -69,7 +70,7 @@ def timeline(data):
     s += '}\n'
     s += '</script>\n'
 
-    return mark_safe(s)
+    return s
 
 
 @register.filter

--- a/mygpo/web/templatetags/devices.py
+++ b/mygpo/web/templatetags/devices.py
@@ -3,7 +3,7 @@ import os.path
 from django import template
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.html import strip_tags
 from django.contrib.staticfiles.storage import staticfiles_storage
 

--- a/mygpo/web/templatetags/devices.py
+++ b/mygpo/web/templatetags/devices.py
@@ -31,6 +31,7 @@ def device_type(device):
     return DEVICE_TYPES_DICT.get(device.type, _('Unknown'))
 
 @register.filter
+@mark_safe
 def device_icon(device):
 
     ua_str = (device.user_agent or '').lower()
@@ -57,7 +58,7 @@ def device_icon(device):
         html = '<img src="%(icon)s" alt="%(caption)s" class="device_icon"/>' \
             % dict(icon=staticfiles_storage.url(os.path.join('clients', icon)),
                    caption=caption)
-        return mark_safe(html)
+        return html
 
     return ''
 

--- a/mygpo/web/templatetags/facebook.py
+++ b/mygpo/web/templatetags/facebook.py
@@ -21,17 +21,19 @@ LIKE_BUTTON_STR = """<iframe class="fb_like" src="//www.facebook.com/plugins/lik
 # http://docs.djangoproject.com/en/dev/howto/custom-template-tags/#shortcut-for-simple-tags
 
 @register.simple_tag
+@mark_safe
 def fb_like_episode(episode, podcast):
     url = 'http://gpodder.net/%s' % get_episode_link_target(episode, podcast)
     s = LIKE_BUTTON_STR % dict(url=url)
-    return mark_safe(s)
+    return s
 
 
 @register.filter
+@mark_safe
 def fb_like_podcast(podcast):
     url = 'http://gpodder.net%s' % get_podcast_link_target(podcast)
     s = LIKE_BUTTON_STR % dict(url=url)
-    return mark_safe(s)
+    return s
 
 
 
@@ -57,6 +59,7 @@ def opengraph_episode(episode, podcast):
     return s
 
 @register.filter
+@mark_safe
 def opengraph_podcast(podcast):
     s = OPENGRAPH_STR % dict(
         title     = podcast.title,
@@ -66,4 +69,4 @@ def opengraph_podcast(podcast):
         site_name = 'gpodder.net',
         admins    = '0'
     )
-    return mark_safe(s)
+    return s

--- a/mygpo/web/templatetags/flickr.py
+++ b/mygpo/web/templatetags/flickr.py
@@ -11,7 +11,8 @@ def is_flickr_photo(url):
     return flickr.is_flickr_image(url)
 
 @register.filter
+@mark_safe
 def embed_flickr_photo(episode):
     img = flickr.get_display_photo(episode.url)
     s = '<a href="%s" title="%s"><img src="%s" alt="%s" /></a>' % (episode.link, episode.title, img, episode.title)
-    return mark_safe(s)
+    return s

--- a/mygpo/web/templatetags/google.py
+++ b/mygpo/web/templatetags/google.py
@@ -10,10 +10,12 @@ register = template.Library()
 
 
 @register.simple_tag
+@mark_safe
 def google_plus_one_head():
-    return mark_safe("""<script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>""")
+    return """<script type="text/javascript" src="https://apis.google.com/js/plusone.js"></script>"""
 
 
 @register.simple_tag
+@mark_safe
 def google_plus_one_button():
-    return mark_safe("""<g:plusone size="medium"></g:plusone>""")
+    return """<g:plusone size="medium"></g:plusone>"""

--- a/mygpo/web/templatetags/googleanalytics.py
+++ b/mygpo/web/templatetags/googleanalytics.py
@@ -4,6 +4,7 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 @register.filter
+@mark_safe
 def google_analytics_async(property_id):
     s = """
     <script type="text/javascript">
@@ -21,4 +22,4 @@ def google_analytics_async(property_id):
         })();
     </script>""" % property_id
 
-    return mark_safe(s)
+    return s

--- a/mygpo/web/templatetags/menu.py
+++ b/mygpo/web/templatetags/menu.py
@@ -71,6 +71,7 @@ MENU_STRUCTURE = (
 )
 
 @register.filter
+@mark_safe
 def main_menu(selected):
     found_section = False
     links = []
@@ -88,8 +89,7 @@ def main_menu(selected):
         else:
             items.append('<li><a href="%s">%s</a></li>' % (uri, ugettext(caption)))
 
-    s = '\n'.join(items)
-    return mark_safe(s)
+    return '\n'.join(items)
 
 def get_section_items(selected):
     for label, items in MENU_STRUCTURE:
@@ -102,6 +102,7 @@ def get_section_items(selected):
     ]
 
 @register.filter
+@mark_safe
 def section_menu(selected, title=None):
 
     items = []
@@ -127,5 +128,4 @@ def section_menu(selected, title=None):
             else:
                 items.append('<li><a href="%s">%s</a></li>' % (uri, ugettext(caption)))
 
-    s = '\n'.join(items)
-    return mark_safe(s)
+    return '\n'.join(items)

--- a/mygpo/web/templatetags/mygpoutil.py
+++ b/mygpo/web/templatetags/mygpoutil.py
@@ -8,6 +8,7 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 @register.filter
+@mark_safe
 def remove_html_tags(html):
     # If we would want more speed, we could make these global
     re_strip_tags = re.compile('<[^>]*>')
@@ -35,4 +36,4 @@ def remove_html_tags(html):
     # Convert more than two newlines to two newlines
     result = re.sub('([\r\n]{2})([\r\n])+', '\\1', result)
 
-    return mark_safe(result.strip())
+    return result.strip()

--- a/mygpo/web/templatetags/podcasts.py
+++ b/mygpo/web/templatetags/podcasts.py
@@ -16,13 +16,13 @@ from mygpo.web.utils import get_podcast_link_target, \
 register = template.Library()
 
 
+@mark_safe
 def create_podcast_logo(podcast, size):
     if not podcast:
         return ''
 
     size = int(size)
-    s = '<img src="%s" alt="" />' % (get_logo_url(podcast, size),)
-    return mark_safe(s)
+    return '<img src="%s" alt="" />' % (get_logo_url(podcast, size),)
 
 @register.filter
 def podcast_logo(podcast):
@@ -38,15 +38,16 @@ def podcast_logo_medium(podcast):
 
 
 @register.filter
+@mark_safe
 def podcast_status_icon(action):
     if action.action == 'subscribe':
-        s = '<img src="%s" />' % (staticfiles_storage.url('subscribe.png'),)
+        return '<img src="%s" />' % (staticfiles_storage.url('subscribe.png'),)
     elif action.action == 'unsubscribe':
-        s = '<img src="%s" />' % (staticfiles_storage.url('unsubscribe.png'),)
+        return '<img src="%s" />' % (staticfiles_storage.url('unsubscribe.png'),)
     elif action.action == 'flattr':
-        s = '<img src="https://flattr.com/_img/icons/flattr_logo_16.png" />'
+        return '<img src="https://flattr.com/_img/icons/flattr_logo_16.png" />'
 
-    return mark_safe(s)
+    return ''
 
 
 @register.filter

--- a/mygpo/web/templatetags/time.py
+++ b/mygpo/web/templatetags/time.py
@@ -24,6 +24,7 @@ def sec_to_time(sec):
 
 
 @register.filter
+@mark_safe
 def format_duration(sec):
     """ Converts seconds into a duration string
 
@@ -34,4 +35,4 @@ def format_duration(sec):
     hours = int(sec / 60 / 60)
     minutes = int((sec / 60) % 60)
     seconds = int(sec % 60)
-    return mark_safe(_('{h}h {m}m {s}s').format(h=hours, m=minutes, s=seconds))
+    return _('{h}h {m}m {s}s').format(h=hours, m=minutes, s=seconds)

--- a/mygpo/web/templatetags/utils.py
+++ b/mygpo/web/templatetags/utils.py
@@ -10,8 +10,9 @@ from mygpo.utils import edit_link
 register = template.Library()
 
 @register.filter
+@mark_safe
 def lookup(dic, key):
-    return mark_safe(dic.get(key, ''))
+    return dic.get(key, '')
 
 @register.filter
 def lookup_list(dict, keys):
@@ -45,9 +46,10 @@ def remove(l, item):
     return [x for x in l if x != item]
 
 @register.filter
+@mark_safe
 def format_time(time):
     from mygpo.utils import format_time as _format_time
-    return mark_safe(_format_time(time))
+    return _format_time(time)
 
 
 @register.filter
@@ -56,18 +58,18 @@ def is_tuple(obj):
 
 
 @register.filter
+@mark_safe
 def markdown(txt):
     import markdown2
-    html = markdown2.markdown(txt, extras={'nofollow': True})
-    return mark_safe(html)
+    return markdown2.markdown(txt, extras={'nofollow': True})
 
 
 @register.filter
+@mark_safe
 def nbsp(s):
     """ collapses multiple whitespaces and replaces them with &nbsp; """
     import re
-    s = re.sub("\s+", "&nbsp;", s)
-    return mark_safe(s)
+    return re.sub("\s+", "&nbsp;", s)
 
 
 @register.filter
@@ -83,11 +85,12 @@ def license_name(license_url):
 
 
 @register.filter
+@mark_safe
 def urlquote(s):
     """ makes urllib.quote_plus available as a template filter """
     if isinstance(s, str):
         s = s.encode('utf-8')
-    return mark_safe(urllib.parse.quote_plus(s))
+    return urllib.parse.quote_plus(s)
 
 
 hours_to_str = register.filter(hours_to_str)

--- a/mygpo/web/templatetags/youtube.py
+++ b/mygpo/web/templatetags/youtube.py
@@ -1,5 +1,4 @@
 from django import template
-from django.utils.safestring import mark_safe
 
 from mygpo.data import youtube
 

--- a/mygpo/web/tests.py
+++ b/mygpo/web/tests.py
@@ -3,7 +3,7 @@ import doctest
 import uuid
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth import get_user_model
 
 from mygpo.podcasts.models import Podcast, Episode, Slug

--- a/mygpo/web/utils.py
+++ b/mygpo/web/utils.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from django.utils.translation import ungettext
 from django.views.decorators.cache import never_cache
 from django.utils.html import strip_tags
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render
 from django.http import Http404
 

--- a/mygpo/web/views.py
+++ b/mygpo/web/views.py
@@ -2,7 +2,7 @@ import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.contrib import messages
 from django.utils.translation import ugettext as _

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.10.7
+Django==1.11.3
 Babel==2.4.0
 Pillow==4.1.1
 celery==3.1.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.3
+Django==1.11.4
 Babel==2.4.0
 Pillow==4.1.1
 celery==3.1.24


### PR DESCRIPTION
https://docs.djangoproject.com/en/dev/releases/1.11/

- [x] ~~Use new index syntax (see https://stackoverflow.com/q/45288539/693140)~~ (there seems to be no straight-forward way to migrate)
- [x] Use LoginView / LogoutView
- [x] "mark_safe() can now be used as a decorator." -- check where that makes sense
- [x] permalink decorator is deprecated
