### PR TITLE
Enable Travis tests for Py 3.6, -dev and PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: python
 
 python:
  - "3.5"
+ - "3.6"
+ - "3.6-dev"
+ - "3.7-dev"
  - "nightly"
+ - "pypy3"
 
 services:
  - redis-server

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ clean:
 
 install-deps:
 	sudo apt-get install libpq-dev libjpeg-dev zlib1g-dev libwebp-dev \
-		build-essential python3-dev virtualenv
+		build-essential python3-dev virtualenv libffi-dev
 
 
 .PHONY: all help test clean unittest coverage install-deps

--- a/mygpo/settings.py
+++ b/mygpo/settings.py
@@ -4,6 +4,13 @@ import os.path
 import dj_database_url
 
 
+try:
+    from psycopg2cffi import compat
+    compat.register()
+except ImportError:
+    pass
+
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ gunicorn==19.7.1
 html2text==2016.9.19
 markdown2==2.3.4
 oauth2client==4.1.1
-psycopg2==2.7.1
+psycopg2cffi==2.7.6
 pyes==0.99.6
 python-dateutil==2.6.0
 redis==2.10.5


### PR DESCRIPTION
Installing `psycopg2` fails with

````
    cc -pthread -DNDEBUG -O2 -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.7.1 (dt dec pq3 ext lo64)" -DPG_VERSION_NUM=90603 -DHAVE_LO64=1 -I/opt/python/pypy3.5-5.8.0/include -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.6/server -c psycopg/adapter_binary.c -o build/temp.linux-x86_64-3.5/psycopg/adapter_binary.o -Wdeclaration-after-statement

    cc -pthread -DNDEBUG -O2 -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.7.1 (dt dec pq3 ext lo64)" -DPG_VERSION_NUM=90603 -DHAVE_LO64=1 -I/opt/python/pypy3.5-5.8.0/include -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.6/server -c psycopg/adapter_datetime.c -o build/temp.linux-x86_64-3.5/psycopg/adapter_datetime.o -Wdeclaration-after-statement

    psycopg/adapter_datetime.c: In function ‘_pydatetime_string_delta’:

    psycopg/adapter_datetime.c:103:16: error: ‘PyDateTime_Delta’ has no member named ‘microseconds’

         int a = obj->microseconds;

                    ^

    psycopg/adapter_datetime.c:112:32: error: ‘PyDateTime_Delta’ has no member named ‘days’

                                 obj->days, obj->seconds, buffer);

                                    ^

    psycopg/adapter_datetime.c:112:43: error: ‘PyDateTime_Delta’ has no member named ‘seconds’

                                 obj->days, obj->seconds, buffer);

                                               ^

    error: command 'cc' failed with exit status 1

````

Possibly [psycopg2cffi](https://pypi.python.org/pypi/psycopg2cffi) might be an alternative.