### PR TITLE
Fix 'obj not defined' error

### DIFF
--- a/mygpo/core/slugs.py
+++ b/mygpo/core/slugs.py
@@ -22,7 +22,7 @@ class SlugGenerator(object):
 
         The consumer can can consume until it get's an unused one """
 
-        if obj.slug:
+        if self.obj.slug:
             # The object already has a slug
             raise StopIteration
 


### PR DESCRIPTION
I have no idea what a slug is, or what the object is, but I kept getting `obj not defined` errors when I did a search on my local mygpo server, and referring to the object variable seems an obvious fix to the problem.  

It seems to work on my installation anyway.