### PR TITLE
[clientconfig] Changed mygpo to https

### DIFF
--- a/static/clientconfig.json
+++ b/static/clientconfig.json
@@ -1,6 +1,6 @@
 {
     "mygpo":  {
-        "baseurl": "http://gpodder.net/"
+        "baseurl": "https://gpodder.net/"
     },
 
     "mygpo-feedservice": {


### PR DESCRIPTION
the client config was returning a http address for the mygpo service.
This is a problem because if a client tries to login using this address, despite the redirect to https, the request would leave the user's machine unencripted containing the authentication info.