### PR TITLE
Added .pytest_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ envs
 notebooks/
 
 .cache
+.pytest_cache


### PR DESCRIPTION
.pytest_cache seems to be generated when running integration tests