### PR TITLE
removing obsolete command from installation instructions.

### DIFF
--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -114,7 +114,6 @@ commands regularly on your development machine:
 
 .. code-block:: bash
 
-    envdir envs/local python manage.py update-categories
     envdir envs/local python manage.py update-toplist
     envdir envs/local python manage.py update-episode-toplist
 


### PR DESCRIPTION
Removing this from the docs as per @stefankoegl:

https://gpodder-net.slack.com/archives/CB5QBHTA8/p1564389664001700?thread_ts=1564274889.000400&cid=CB5QBHTA8