### PR TITLE
Update doc/user/clients.rst to reflect current status

### DIFF
--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -22,7 +22,7 @@ Name                  Status     gpodder.net features                   License 
 `Podcatcher Deluxe`_  Dead       Sync of subscriptions and actions      GPL 3
 `Podcast Addict`_     Active     none                                             `Podcast Addict export script`_
 `Podkicker`_          Active     none
-`SoundWaves`_         Active     Subscriptions sync                     GPL 3
+`SoundWaves`_         Abandoned  Subscriptions sync                     GPL 3
 ====================  =========  =====================================  ========  ==================================================
 
 

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -11,17 +11,17 @@ Android
 ====================  =========  =====================================  ========  ==================================================
 Name                  Status     gpodder.net features                   License   Documentation
 ====================  =========  =====================================  ========  ==================================================
+`AntennaPod`_         Active     Directory, Search, Subscription sync   MIT
+`Listen Up Free`_     Active     sync, subscription, search
+`Podcast Addict`_     Active     none                                             `Podcast Addict export script`_
+`Podkicker`_          Active     none
 `Podax`_              Abandoned  Subscription sync                      BSD
 `Volksempfänger`_     Abandoned  Podcast search                         ISC
 `SwallowCatcher`_     Abandoned  Planned                                AGPL
 `Detlef Gpodderson`_  Abandoned  Subscription and Episode Action sync   GPL       `Detlef Repository`_
-`AntennaPod`_         Active     Directory, Search, Subscription sync   MIT
 `gpodroid`_           Abandoned  Subscriptions only                     EPL       `gpodroid Repository`_
 `Podstars`_           Abandoned  Podcast search
-`Listen Up Free`_     Active     sync, subscription, search
 `Podcatcher Deluxe`_  Dead       Sync of subscriptions and actions      GPL 3
-`Podcast Addict`_     Active     none                                             `Podcast Addict export script`_
-`Podkicker`_          Active     none
 `SoundWaves`_         Abandoned  Subscriptions sync                     GPL 3
 ====================  =========  =====================================  ========  ==================================================
 

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -14,7 +14,7 @@ Name                  Status     gpodder.net features                   License 
 `Podax`_              Active     Subscription sync                      BSD
 `Volksempfänger`_     Abandoned  Podcast search                         ISC
 `SwallowCatcher`_     Abandoned  Planned                                AGPL
-`Detlef Gpodderson`_  Active     Subscription and Episode Action sync   GPL       `Detlef Repository`_
+`Detlef Gpodderson`_  Abandoned  Subscription and Episode Action sync   GPL       `Detlef Repository`_
 `AntennaPod`_         Active     Directory, Search, Subscription sync   MIT
 `gpodroid`_           Abandoned  Subscriptions only                     EPL       `gpodroid Repository`_
 `Podstars`_           Active     Podcast search

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -19,7 +19,7 @@ Name                  Status     gpodder.net features                   License 
 `gpodroid`_           Abandoned  Subscriptions only                     EPL       `gpodroid Repository`_
 `Podstars`_           Active     Podcast search
 `Listen Up Free`_     Active     sync, subscription, search
-`Podcatcher Deluxe`_  Active     Sync of subscriptions and actions      GPL 3
+`Podcatcher Deluxe`_  Dead       Sync of subscriptions and actions      GPL 3
 `Podcast Addict`_     Active     none                                             `Podcast Addict export script`_
 `Podkicker`_          Active     none
 `SoundWaves`_         Active     Subscriptions sync                     GPL 3

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -8,22 +8,22 @@ Clients
 Android
 -------
 
-====================  =========  =====================================  ========  ==================================================
-Name                  Status     gpodder.net features                   License   Documentation
-====================  =========  =====================================  ========  ==================================================
-`AntennaPod`_         Active     Directory, Search, Subscription sync   MIT
-`Listen Up Free`_     Active     sync, subscription, search
-`Podcast Addict`_     Active     none                                             `Podcast Addict export script`_
-`Podkicker`_          Active     none
-`Podax`_              Abandoned  Subscription sync                      BSD
-`Volksempfänger`_     Abandoned  Podcast search                         ISC
-`SwallowCatcher`_     Abandoned  Planned                                AGPL
-`Detlef Gpodderson`_  Abandoned  Subscription and Episode Action sync   GPL       `Detlef Repository`_
-`gpodroid`_           Abandoned  Subscriptions only                     EPL       `gpodroid Repository`_
-`Podstars`_           Abandoned  Podcast search
-`Podcatcher Deluxe`_  Dead       Sync of subscriptions and actions      GPL 3
-`SoundWaves`_         Abandoned  Subscriptions sync                     GPL 3
-====================  =========  =====================================  ========  ==================================================
+====================  ==========  =====================================  ========  ==================================================
+Name                  Status      gpodder.net features                   License   Documentation
+====================  ==========  =====================================  ========  ==================================================
+`AntennaPod`_         Active      Directory, Search, Subscription sync   MIT
+`Listen Up Free`_     Active      sync, subscription, search
+`Podcast Addict`_     Active      none                                             `Podcast Addict export script`_
+`Podkicker`_          Active      none
+`Podax`_              Abandoned   Subscription sync                      BSD
+`Volksempfänger`_     Abandoned   Podcast search                         ISC
+`SwallowCatcher`_     Abandoned   Planned                                AGPL
+`Detlef Gpodderson`_  Abandoned   Subscription and Episode Action sync   GPL       `Detlef Repository`_
+`gpodroid`_           Abandoned   Subscriptions only                     EPL       `gpodroid Repository`_
+`Podstars`_           Abandoned   Podcast search
+`Podcatcher Deluxe`_  Deprecated  Sync of subscriptions and actions      GPL 3
+`SoundWaves`_         Abandoned   Subscriptions sync                     GPL 3
+====================  ==========  =====================================  ========  ==================================================
 
 
 Mac OS X

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -13,7 +13,7 @@ Name                  Status     gpodder.net features                   License 
 ====================  =========  =====================================  ========  ==================================================
 `Podax`_              Active     Subscription sync                      BSD
 `Volksempfänger`_     Abandoned  Podcast search                         ISC
-`SwallowCatcher`_     Active     Planned                                AGPL
+`SwallowCatcher`_     Abandoned  Planned                                AGPL
 `Detlef Gpodderson`_  Active     Subscription and Episode Action sync   GPL       `Detlef Repository`_
 `AntennaPod`_         Active     Directory, Search, Subscription sync   MIT
 `gpodroid`_           Abandoned  Subscriptions only                     EPL       `gpodroid Repository`_

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -11,7 +11,7 @@ Android
 ====================  =========  =====================================  ========  ==================================================
 Name                  Status     gpodder.net features                   License   Documentation
 ====================  =========  =====================================  ========  ==================================================
-`Podax`_              Active     Subscription sync                      BSD
+`Podax`_              Abandoned  Subscription sync                      BSD
 `Volksempfänger`_     Abandoned  Podcast search                         ISC
 `SwallowCatcher`_     Abandoned  Planned                                AGPL
 `Detlef Gpodderson`_  Abandoned  Subscription and Episode Action sync   GPL       `Detlef Repository`_

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -19,7 +19,6 @@ Name                  Status     gpodder.net features                   License 
 `gpodroid`_           Abandoned  Subscriptions only                     EPL       `gpodroid Repository`_
 `Podstars`_           Active     Podcast search
 `Listen Up Free`_     Active     sync, subscription, search
-`Feed Farmer`_        Active     Search, Toplist
 `Podcatcher Deluxe`_  Active     Sync of subscriptions and actions      GPL 3
 `Podcast Addict`_     Active     none                                             `Podcast Addict export script`_
 `Podkicker`_          Active     none

--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -17,7 +17,7 @@ Name                  Status     gpodder.net features                   License 
 `Detlef Gpodderson`_  Abandoned  Subscription and Episode Action sync   GPL       `Detlef Repository`_
 `AntennaPod`_         Active     Directory, Search, Subscription sync   MIT
 `gpodroid`_           Abandoned  Subscriptions only                     EPL       `gpodroid Repository`_
-`Podstars`_           Active     Podcast search
+`Podstars`_           Abandoned  Podcast search
 `Listen Up Free`_     Active     sync, subscription, search
 `Podcatcher Deluxe`_  Dead       Sync of subscriptions and actions      GPL 3
 `Podcast Addict`_     Active     none                                             `Podcast Addict export script`_


### PR DESCRIPTION
Update `doc/user/clients.rst` to reflect current status of android clients:

- Mark `SwallowCatcher` as abandoned. Download, source code and announcement links are all dead on their website.
- Mark `Detlef Gpodderson` as abandoned. Last commit to repo 5 years ago and the testing version of the app isn't available.
- Remove `FeedFarmer`. No signs that this app exists anymore.
- Mark `Podcatcher Deluxe` as dead. Link to website explains why it is no longer being maintained.
- Mark `SoudWaves` as abandoned. No commits or comments on issues since March 2018.
- Mark `Podax` as abandoned. README.md says as much.
- Mark `Podstars` as abandoned. No signs that this app exists anymore.
- Reorder android clients to put active ones at the top.
- Mark `Podcaster Deluxe` as deprecated to match the style of rest of document.
