### PR TITLE
Increase Simple API test coverage

### DIFF
--- a/mygpo/administration/tests.py
+++ b/mygpo/administration/tests.py
@@ -6,8 +6,6 @@ Replace this with more appropriate tests for your application.
 """
 
 import uuid
-import time
-from datetime import datetime
 from collections import Counter
 
 from django.test import TestCase

--- a/mygpo/api/__init__.py
+++ b/mygpo/api/__init__.py
@@ -49,7 +49,7 @@ class APIView(View):
             # TODO: implementation of parse_request_body can be moved here
             # after all views using it have been refactored
             return parse_request_body(request)
-        except (UnicodeDecodeError, ValueError) as e:
+        except (UnicodeDecodeError, ValueError):
             msg = 'Could not decode request body for user {}: {}'.format(
                 request.user.username, request.body.decode('ascii', errors='replace')
             )

--- a/mygpo/api/legacy.py
+++ b/mygpo/api/legacy.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.http import HttpResponse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.csrf import csrf_exempt
@@ -8,7 +6,6 @@ from django.contrib.auth import get_user_model
 
 from mygpo.podcasts.models import Podcast
 from mygpo.api.opml import Importer, Exporter
-from mygpo.users.models import SubscriptionException
 from mygpo.api.backend import get_device
 from mygpo.utils import normalize_feed_url
 from mygpo.subscriptions import subscribe, unsubscribe

--- a/mygpo/api/simple.py
+++ b/mygpo/api/simple.py
@@ -1,6 +1,5 @@
 import json
 import string
-from itertools import islice
 from functools import wraps
 
 from django.shortcuts import render
@@ -35,7 +34,7 @@ ALLOWED_FORMATS = ('txt', 'opml', 'json', 'jsonp', 'xml')
 def check_format(fn):
     @wraps(fn)
     def tmp(request, format, *args, **kwargs):
-        if not format in ALLOWED_FORMATS:
+        if format not in ALLOWED_FORMATS:
             return HttpResponseBadRequest('Invalid format')
 
         return fn(request, *args, format=format, **kwargs)
@@ -251,9 +250,6 @@ def toplist(request, count, format):
     if scale not in range(1, 257):
         return HttpResponseBadRequest('scale_logo has to be a number from 1 to 256')
 
-    def get_podcast(t):
-        return t
-
     def json_map(t):
         podcast = t
         p = podcast_data(podcast, domain, scale)
@@ -264,7 +260,7 @@ def toplist(request, count, format):
         entries,
         format,
         title,
-        get_podcast=get_podcast,
+        get_podcast=lambda t: t,
         json_map=json_map,
         jsonp_padding=request.GET.get('jsonp', ''),
         xml_template='podcasts.xml',

--- a/mygpo/api/tests.py
+++ b/mygpo/api/tests.py
@@ -284,7 +284,9 @@ class SimpleAPITests(unittest.TestCase):
             'HTTP_AUTHORIZATION': create_auth_string(self.username, self.password)
         }
         self.formats = ['txt', 'json', 'jsonp', 'opml']
-        self.subscriptions_urls = dict((fmt, self.get_subscriptions_url(fmt)) for fmt in self.formats)
+        self.subscriptions_urls = dict(
+            (fmt, self.get_subscriptions_url(fmt)) for fmt in self.formats
+        )
         self.blank_values = {
             'txt': b'\n',
             'json': b'[]',
@@ -292,23 +294,17 @@ class SimpleAPITests(unittest.TestCase):
         }
         self.all_subscriptions_url = reverse(
             'api-all-subscriptions',
-            kwargs={
-                'format': 'txt',
-                'username': self.user.username,
-            },
+            kwargs={'format': 'txt', 'username': self.user.username},
         )
-        self.toplist_urls = dict((fmt, self.get_toplist_url(fmt)) for fmt in self.formats)
+        self.toplist_urls = dict(
+            (fmt, self.get_toplist_url(fmt)) for fmt in self.formats
+        )
 
     def tearDown(self):
         self.user.delete()
 
     def get_toplist_url(self, fmt):
-        return reverse(
-            'api-simple-toplist-50',
-            kwargs={
-                'format': fmt,
-            },
-        )
+        return reverse('api-simple-toplist-50', kwargs={'format': fmt})
 
     def get_subscriptions_url(self, fmt):
         return reverse(
@@ -343,7 +339,9 @@ class SimpleAPITests(unittest.TestCase):
         podcast = Podcast.objects.get_or_create_for_url(
             sample_url, defaults={'title': 'My Podcast'}
         ).object
-        with unittest.mock.patch('mygpo.users.models.Client.get_subscribed_podcasts') as mock_get:
+        with unittest.mock.patch(
+            'mygpo.users.models.Client.get_subscribed_podcasts'
+        ) as mock_get:
             mock_get.return_value = [podcast]
             response = self.client.get(self.subscriptions_urls['txt'], **self.extra)
         self.assertEqual(response.status_code, 200, response.content)
@@ -361,7 +359,6 @@ class SimpleAPITests(unittest.TestCase):
             'json': json.dumps([sample_url]),
             #'opml': Exporter('Subscriptions').generate([sample_url]),
             'opml': Exporter('Subscriptions').generate([podcast]),
-
         }
         payloads = dict(
             (fmt, format_podcast_list([podcast], fmt, 'test title').content)
@@ -380,11 +377,15 @@ class SimpleAPITests(unittest.TestCase):
         self.assertEqual(response.status_code, 400, response.content)
 
     def test_get_all_subscriptions_invalid_scale(self):
-        response = self.client.get(self.all_subscriptions_url, data={'scale_logo': 0}, **self.extra)
+        response = self.client.get(
+            self.all_subscriptions_url, data={'scale_logo': 0}, **self.extra
+        )
         self.assertEqual(response.status_code, 400, response.content)
 
     def test_get_all_subscriptions_non_numeric_scale(self):
-        response = self.client.get(self.all_subscriptions_url, data={'scale_logo': 'a'}, **self.extra)
+        response = self.client.get(
+            self.all_subscriptions_url, data={'scale_logo': 'a'}, **self.extra
+        )
         self.assertEqual(response.status_code, 400, response.content)
 
     def test_get_all_subscriptions_valid_empty(self):
@@ -392,11 +393,15 @@ class SimpleAPITests(unittest.TestCase):
         self.assertEqual(response.status_code, 200, response.content)
 
     def test_get_toplist_invalid_scale(self):
-        response = self.client.get(self.toplist_urls['opml'], data={'scale_logo': 0}, **self.extra)
+        response = self.client.get(
+            self.toplist_urls['opml'], data={'scale_logo': 0}, **self.extra
+        )
         self.assertEqual(response.status_code, 400, response.content)
 
     def test_get_toplist_non_numeric_scale(self):
-        response = self.client.get(self.toplist_urls['txt'], data={'scale_logo': 'a'}, **self.extra)
+        response = self.client.get(
+            self.toplist_urls['txt'], data={'scale_logo': 'a'}, **self.extra
+        )
         self.assertEqual(response.status_code, 400, response.content)
 
     def test_get_toplist_valid_empty(self):

--- a/mygpo/api/tests.py
+++ b/mygpo/api/tests.py
@@ -1,8 +1,7 @@
-import json
-import uuid
 import copy
-import unittest
 from datetime import datetime, timedelta
+import json
+import unittest
 from urllib.parse import urlencode
 
 from django.test.client import Client
@@ -13,8 +12,10 @@ from django.test.utils import override_settings
 
 from mygpo.podcasts.models import Podcast, Episode
 from mygpo.api.advanced import episodes
+from mygpo.api.opml import Exporter, Importer
+from mygpo.api.simple import format_podcast_list
 from mygpo.history.models import EpisodeHistoryEntry
-from mygpo.test import create_auth_string, anon_request
+from mygpo.test import create_auth_string
 from mygpo.utils import get_timestamp
 
 
@@ -266,3 +267,138 @@ class EpisodeActionTests(TestCase):
         # last returned action
         self.assertGreaterEqual(returned, t1)
         self.assertGreaterEqual(t2, returned)
+
+
+class SimpleAPITests(unittest.TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.password = 'asdf'
+        self.username = 'subscription-api-user'
+        self.device_uid = 'test-device'
+        self.user = User(username=self.username, email='user@example.com')
+        self.user.set_password(self.password)
+        self.user.save()
+        self.user.is_active = True
+        self.client = Client()
+        self.extra = {
+            'HTTP_AUTHORIZATION': create_auth_string(self.username, self.password)
+        }
+        self.formats = ['txt', 'json', 'jsonp', 'opml']
+        self.subscriptions_urls = dict((fmt, self.get_subscriptions_url(fmt)) for fmt in self.formats)
+        self.blank_values = {
+            'txt': b'\n',
+            'json': b'[]',
+            'opml': Exporter('Subscriptions').generate([]),
+        }
+        self.all_subscriptions_url = reverse(
+            'api-all-subscriptions',
+            kwargs={
+                'format': 'txt',
+                'username': self.user.username,
+            },
+        )
+        self.toplist_urls = dict((fmt, self.get_toplist_url(fmt)) for fmt in self.formats)
+
+    def tearDown(self):
+        self.user.delete()
+
+    def get_toplist_url(self, fmt):
+        return reverse(
+            'api-simple-toplist-50',
+            kwargs={
+                'format': fmt,
+            },
+        )
+
+    def get_subscriptions_url(self, fmt):
+        return reverse(
+            'api-simple-subscriptions',
+            kwargs={
+                'format': fmt,
+                'username': self.user.username,
+                'device_uid': self.device_uid,
+            },
+        )
+
+    def test_get_subscriptions_empty(self):
+        testers = {
+            'txt': lambda c: self.assertEqual(c, b''),
+            'json': lambda c: self.assertEqual(c, b'[]'),
+            'jsonp': lambda c: self.assertEqual(c, b'test([])'),
+            'opml': lambda c: self.assertListEqual(Importer(c).items, []),
+        }
+        for fmt in self.formats:
+            url = self.subscriptions_urls[fmt]
+            response = self.client.get(url, data={'jsonp': 'test'}, **self.extra)
+            self.assertEqual(response.status_code, 200, response.content)
+            testers[fmt](response.content)
+
+    def test_get_subscriptions_invalid_jsonp(self):
+        url = self.subscriptions_urls['jsonp']
+        response = self.client.get(url, data={'jsonp': '!'}, **self.extra)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_get_subscriptions_with_content(self):
+        sample_url = 'http://example.com/directory-podcast.xml'
+        podcast = Podcast.objects.get_or_create_for_url(
+            sample_url, defaults={'title': 'My Podcast'}
+        ).object
+        with unittest.mock.patch('mygpo.users.models.Client.get_subscribed_podcasts') as mock_get:
+            mock_get.return_value = [podcast]
+            response = self.client.get(self.subscriptions_urls['txt'], **self.extra)
+        self.assertEqual(response.status_code, 200, response.content)
+        retrieved_urls = response.content.split(b'\n')[:-1]
+        expected_urls = [sample_url.encode()]
+        self.assertEqual(retrieved_urls, expected_urls)
+
+    def test_post_subscription_valid(self):
+        sample_url = 'http://example.com/directory-podcast.xml'
+        podcast = Podcast.objects.get_or_create_for_url(
+            sample_url, defaults={'title': 'My Podcast'}
+        ).object
+        payloads = {
+            'txt': sample_url,
+            'json': json.dumps([sample_url]),
+            #'opml': Exporter('Subscriptions').generate([sample_url]),
+            'opml': Exporter('Subscriptions').generate([podcast]),
+
+        }
+        payloads = dict(
+            (fmt, format_podcast_list([podcast], fmt, 'test title').content)
+            for fmt in self.formats
+        )
+        for fmt in self.formats:
+            url = self.subscriptions_urls[fmt]
+            payload = payloads[fmt]
+            response = self.client.generic('POST', url, payload, **self.extra)
+            self.assertEqual(response.status_code, 200, response.content)
+
+    def test_post_subscription_invalid(self):
+        url = self.subscriptions_urls['json']
+        payload = 'invalid_json'
+        response = self.client.generic('POST', url, payload, **self.extra)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_get_all_subscriptions_invalid_scale(self):
+        response = self.client.get(self.all_subscriptions_url, data={'scale_logo': 0}, **self.extra)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_get_all_subscriptions_non_numeric_scale(self):
+        response = self.client.get(self.all_subscriptions_url, data={'scale_logo': 'a'}, **self.extra)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_get_all_subscriptions_valid_empty(self):
+        response = self.client.get(self.all_subscriptions_url, **self.extra)
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_get_toplist_invalid_scale(self):
+        response = self.client.get(self.toplist_urls['opml'], data={'scale_logo': 0}, **self.extra)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_get_toplist_non_numeric_scale(self):
+        response = self.client.get(self.toplist_urls['txt'], data={'scale_logo': 'a'}, **self.extra)
+        self.assertEqual(response.status_code, 400, response.content)
+
+    def test_get_toplist_valid_empty(self):
+        response = self.client.get(self.toplist_urls['json'], **self.extra)
+        self.assertEqual(response.status_code, 200, response.content)

--- a/mygpo/api/urls.py
+++ b/mygpo/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, register_converter
 
-from . import legacy, simple, advanced, advanced, subscriptions
+from . import legacy, simple, advanced, subscriptions
 from .advanced import auth, lists, sync, updates, episode, settings
 from mygpo.users import converters
 from mygpo.usersettings.converters import ScopeConverter
@@ -13,24 +13,38 @@ register_converter(ScopeConverter, 'scope')
 urlpatterns = [
     path('upload', legacy.upload),
     path('getlist', legacy.getlist),
-    path('toplist.opml', simple.toplist, kwargs={'count': 50, 'format': 'opml'}),
     path(
         'subscriptions/<username:username>/' '<client-uid:device_uid>.<str:format>',
         simple.subscriptions,
+        name='api-simple-subscriptions',
     ),
     path(
         'subscriptions/<username:username>.<str:format>',
         simple.all_subscriptions,
         name='api-all-subscriptions',
     ),
-    path('toplist/<int:count>.<str:format>', simple.toplist, name='toplist-opml'),
     path('search.<str:format>', simple.search),
     path(
         'suggestions/<int:count>.<str:format>',
         simple.suggestions,
         name='suggestions-opml',
     ),
-    path('toplist.<str:format>', simple.toplist, kwargs={'count': 50}),
+    path(
+        'toplist.opml',
+        simple.toplist,
+        kwargs={'count': 50, 'format': 'opml'},
+        name='api-simple-toplist.opml',
+    ),
+    path(
+        'toplist/<int:count>.<str:format>',
+        simple.toplist,
+        name='api-simple-toplist'
+    ),
+    path(
+        'toplist.<str:format>',
+        simple.toplist, kwargs={'count': 50},
+        name='api-simple-toplist-50',
+    ),
     path('gpodder-examples.<str:format>', simple.example_podcasts, name='example-opml'),
     path(
         'api/<int:version>/subscriptions/<username:username>/'

--- a/mygpo/api/urls.py
+++ b/mygpo/api/urls.py
@@ -35,14 +35,11 @@ urlpatterns = [
         kwargs={'count': 50, 'format': 'opml'},
         name='api-simple-toplist.opml',
     ),
-    path(
-        'toplist/<int:count>.<str:format>',
-        simple.toplist,
-        name='api-simple-toplist'
-    ),
+    path('toplist/<int:count>.<str:format>', simple.toplist, name='api-simple-toplist'),
     path(
         'toplist.<str:format>',
-        simple.toplist, kwargs={'count': 50},
+        simple.toplist,
+        kwargs={'count': 50},
         name='api-simple-toplist-50',
     ),
     path('gpodder-examples.<str:format>', simple.example_podcasts, name='example-opml'),

--- a/mygpo/directory/templates/toplist.html
+++ b/mygpo/directory/templates/toplist.html
@@ -87,7 +87,7 @@
    <div class="well">
    <h4>{% trans "Client Access" %}</h4>
 
-    <p>Access <a href="{% url "toplist-opml" 30 "opml" %}">http://{{ view.site }}{% url "toplist-opml" 30 "opml" %}</a> for the Top-30.</p>
+    <p>Access <a href="{% url "api-simple-toplist" 30 "opml" %}">http://{{ view.site }}{% url "api-simple-toplist" 30 "opml" %}</a> for the Top-30.</p>
  </div>
 
 {% endblock %}

--- a/mygpo/test.py
+++ b/mygpo/test.py
@@ -1,4 +1,3 @@
-import os.path
 import base64
 
 from django.urls import resolve

--- a/mygpo/users/models.py
+++ b/mygpo/users/models.py
@@ -1,5 +1,4 @@
 import re
-import uuid
 import collections
 import dateutil.parser
 
@@ -22,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 RE_DEVICE_UID = re.compile(r'^[\w.-]+$')
+
 
 # TODO: derive from ValidationException?
 class InvalidEpisodeActionAttributes(ValueError):
@@ -103,7 +103,7 @@ class UserProxy(DjangoUser):
         for client in clients:
             # check if we have just found a new group
             if last_group != client.sync_group:
-                if group != None:
+                if group is not None:
                     yield group
 
                 group = GroupedDevices(client.sync_group is not None, [])
@@ -112,7 +112,7 @@ class UserProxy(DjangoUser):
             group.devices.append(client)
 
         # yield remaining group
-        if group != None:
+        if group is not None:
             yield group
 
 
@@ -308,8 +308,6 @@ class Client(UUIDModel, DeleteableModel):
         """ Returns the devices and groups with which the device can be synced
 
         Groups are represented as lists of devices """
-
-        sg = self.sync_group
 
         user = UserProxy.objects.from_user(self.user)
         for group in user.get_grouped_devices():


### PR DESCRIPTION
For #233
Some clean up:
    Rename urls for toplist
    Remove unused imports and variable assignment
    Use "is not None" instead of "!= None"
Add SimpleAPITests to test views from mygpo.api.simple