### PR TITLE
always return "released" attribute of episode_data

### DIFF
--- a/mygpo/api/advanced/directory.py
+++ b/mygpo/api/advanced/directory.py
@@ -135,6 +135,8 @@ def episode_data(episode, domain, podcast=None):
 
     if episode.released:
         data['released'] = episode.released.strftime('%Y-%m-%dT%H:%M:%S')
+    else:
+        data['released'] = ''
 
     return data
 


### PR DESCRIPTION
Return empty string for "released" attribute of episode_data when no value is set.  Follows the same logic as "podcast_url" among others.

I'm using the python client library and "released" is in REQUIRED_KEYS which generates an error when no key is present in response. I'm assuming that the preference would be this proposed fix, as opposed to fixing in the client.