### PR TITLE
API for adding new podcast.

### DIFF
--- a/mygpo/api/advanced/directory.py
+++ b/mygpo/api/advanced/directory.py
@@ -1,4 +1,7 @@
+import json
+
 from django.http import Http404
+from django.http.response import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.contrib.sites.requests import RequestSite
 from django.views.decorators.csrf import csrf_exempt
@@ -14,6 +17,8 @@ from mygpo.subscriptions.models import SubscribedPodcast
 from mygpo.decorators import cors_origin
 from mygpo.categories.models import Category
 from mygpo.api.httpresponse import JsonResponse
+from mygpo.data.tasks import update_podcasts
+from mygpo.decorators import allowed_methods
 
 
 @csrf_exempt
@@ -84,6 +89,54 @@ def episode_info(request):
     domain = RequestSite(request).domain
 
     resp = episode_data(episode, domain)
+    return JsonResponse(resp)
+
+
+@csrf_exempt
+@allowed_methods(['POST'])
+@cors_origin()
+def add_podcast(request):
+    # TODO what if the url doesn't have a valid podcast?
+    url = normalize_feed_url(json.loads(request.body.decode('utf-8')).get('url', ''))
+
+    # 404 before we query for url, because query would complain
+    # about missing param
+    if not url:
+        raise Http404
+
+    try:
+        # podcast exists, redirects
+        Podcast.objects.get(urls__url=url)
+        api_podcast_info_path = reverse('api-podcast-info')
+        return HttpResponseRedirect(f'{api_podcast_info_path}?url={url}')
+    except Podcast.DoesNotExist:
+        # podcast doesn't exist, add new podcast
+        res = update_podcasts.delay([url])
+        response = HttpResponse(status=202)
+        job_status_path = reverse(
+            'api-add-podcast-status', kwargs={"job_id": res.task_id}
+        )
+        response['Location'] = f'{job_status_path}?url={url}'
+        return response
+
+
+@csrf_exempt
+@allowed_methods(['GET'])
+@cors_origin()
+def add_podcast_status(request, job_id):
+    url = request.GET.get('url', '')
+    result = update_podcasts.AsyncResult(job_id)
+    resp = {'id': str(job_id), 'type': 'create-podcast', 'url': url}
+
+    if not result.ready():
+        resp['status'] = 'pending'
+    elif result.successful():
+        resp['status'] = 'successful'
+        resp['podcast'] = f'/api/2/data/podcast.json?url={url}'
+    elif result.failed():
+        resp['status'] = 'unsuccessful'
+        resp['error'] = 'feed could not be parsed'
+
     return JsonResponse(resp)
 
 

--- a/mygpo/api/urls.py
+++ b/mygpo/api/urls.py
@@ -59,11 +59,21 @@ urlpatterns = [
     path('api/2/auth/<username:username>/logout.json', auth.logout),
     path('api/2/tags/<int:count>.json', advanced.directory.top_tags),
     path('api/2/tag/<str:tag>/<int:count>.json', advanced.directory.tag_podcasts),
-    path('api/2/data/podcast.json', advanced.directory.podcast_info),
+    path(
+        'api/2/data/podcast.json',
+        advanced.directory.podcast_info,
+        name='api-podcast-info',
+    ),
     path(
         'api/2/data/episode.json',
         advanced.directory.episode_info,
         name='api-episode-info',
+    ),
+    path('api/2/podcasts/create', advanced.directory.add_podcast),
+    path(
+        'api/2/task/<uuid:job_id>',
+        advanced.directory.add_podcast_status,
+        name='api-add-podcast-status',
     ),
     path('api/2/chapters/<username:username>.json', episode.ChaptersAPI.as_view()),
     path(


### PR DESCRIPTION
Addressing "Add new podcast by API · Issue #219 · gpodder/mygpo"

- [x] API views
- [ ] Pass CI builds
- [ ] Testing
- [ ] Documentation
- [ ] Check edge case - Podcast URL not exist
- [ ] Check edge case - Podcast XML format error
- [ ] Code reviews

If I add an URL that doesn't exist at all, e.g. https://example.com/podcast/feed.xml, [update_podcasts.AsyncResult](https://github.com/gpodder/mygpo/compare/master...SiqingYu:add-podcast-api?expand=1#diff-0e1a810669f7176d59c50d81ec348815R126) still returns successfully. Is this expected or not?

Example response for existed URL (automatically redirected):
```
{
    "url": "https://changelog.com/podcast/feed",
    "title": "The Changelog",
    "description": "Conversations with the hackers, leaders, and innovators of software\ndevelopment. Hosts Adam Stacoviak and Jerod Santo face their imposter syndrome\nso you don’t have to. Expect in-depth interviews with the best and brightest\nin software engineering, open source, and leadership. This is a polyglot\npodcast. All programming languages, platforms, and communities are welcome.\nOpen source moves fast. Keep up.",
    "subscribers": 0,
    "subscribers_last_week": 0,
    "logo_url": "https://cdn.changelog.com/uploads/covers/the-changelog-original.png?v=63725770322",
    "scaled_logo_url": "http://www.siqingyuwebdev.xyz:8000/logo/64/889/889b1ae061ee57eb0e2161ed83e5d8a3def9f598",
    "website": "https://changelog.com/podcast",
    "mygpo_link": "http://www.siqingyuwebdev.xyz:8000/podcast/the-changelog"
}
```

Example response for an URL that doesn't exist in the database:
![image](https://user-images.githubusercontent.com/22290018/72222116-5d9d9480-359c-11ea-8f15-50b93d211da3.png)

Example response for job status:
```
{
    "id": "8b19ae4b-8fea-4876-9b13-ef89e1e2a773",
    "type": "create-podcast",
    "url": "https://example.com/podcast/feed.xml",
    "status": "successful",
    "podcast": "/api/2/data/podcast.json?url=https://example.com/podcast/feed.xml"
}
```

Notice that the URL https://example.com/podcast/feed.xml doesn't exist, but the result is successful.
