### PR TITLE
Fix failing tests

### DIFF
--- a/mygpo/administration/tests.py
+++ b/mygpo/administration/tests.py
@@ -76,7 +76,7 @@ class SimpleTest(TestCase):
         actions = Counter()
 
         # decide which episodes to merge
-        groups = [(0, [e1]), (1, [e2, e3]), (2, [e4])]
+        groups = [(0, [e1.id]), (1, [e2.id, e3.id]), (2, [e4.id])]
 
         # carry out the merge
         pm = PodcastMerger([p1, p2], actions, groups)

--- a/mygpo/maintenance/tests.py
+++ b/mygpo/maintenance/tests.py
@@ -39,7 +39,7 @@ class SimpleMergeTests(TestCase):
 
     def test_merge_podcasts(self):
         # decide which episodes to merge
-        groups = [(0, [self.episode1, self.episode2])]
+        groups = [(0, [self.episode1.id, self.episode2.id])]
         counter = Counter()
         pm = PodcastMerger([self.podcast1, self.podcast2], counter, groups)
         pm.merge()
@@ -85,7 +85,7 @@ class MergeTests(TransactionTestCase):
         )
 
         # decide which episodes to merge
-        groups = [(0, [self.episode1, self.episode2])]
+        groups = [(0, [self.episode1.id, self.episode2.id])]
         counter = Counter()
 
         pm = PodcastMerger([self.podcast1, self.podcast2], counter, groups)
@@ -160,7 +160,7 @@ class MergeGroupTests(TransactionTestCase):
         )
 
         # decide which episodes to merge
-        groups = [(0, [self.episode1, self.episode2])]
+        groups = [(0, [self.episode1.id, self.episode2.id])]
         counter = Counter()
 
         episode2_id = self.episode2.id


### PR DESCRIPTION
31c997edc3523345b78c4c1ece7241ce67b0865b updated `PodcastMerger.groups`
from expecting a dictionary of form/; "episode_id->[episodes]", to expecting a
dictionary of form: "episode_id->[episode_ids]". Update tests to reflect this
change.