### PR TITLE
Added author to API

### DIFF
--- a/doc/api/reference/directory.rst
+++ b/doc/api/reference/directory.rst
@@ -66,6 +66,7 @@ Retrieve Podcasts for Tag
         [
          {"url": "http://leo.am/podcasts/floss",
           "title": "FLOSS Weekly",
+          "author": "Leo Laporte",
           "description": "Each Thursday we talk about Free Libre and Open Source Software with the people who are writing it. Part of the TWiT Netcast Network.",
           "subscribers": 1138,
           "logo_url: "http://leoville.tv/podcasts/coverart/floss144audio.jpg",
@@ -74,6 +75,7 @@ Retrieve Podcasts for Tag
 
          {"url": "http://leo.am/podcasts/twit",
           "title": "this WEEK in TECH - MP3 Edition",
+          "author": "Leo Laporte",
           "description": "Your first podcast of the week is the last word in tech. [...]",
           "subscribers": 895,
           "logo_url": "http://leoville.tv/podcasts/coverart/twit144audio.jpg",
@@ -109,6 +111,7 @@ Retrieve Podcast Data
          "description": "The best cover songs, delivered to your ears two to three times a week!",
          "subscribers": 19,
          "title": "Coverville",
+         "author": "Brian Ibbott",
          "url": "http://feeds.feedburner.com/coverville",
          "subscribers_last_week": 19,
          "logo_url": "http://www.coverville.com/art/coverville_iTunes300.jpg"
@@ -177,6 +180,7 @@ Podcast Toplist
            "website": "http://linuxoutlaws.com/podcast",
            "description": "Open source talk with a serious attitude",
            "title": "Linux Outlaws",
+           "author": "Sixgun Productions",
            "url": "http://feeds.feedburner.com/linuxoutlaws",
            "position_last_week": 0,
            "subscribers_last_week": 1736,
@@ -188,6 +192,7 @@ Podcast Toplist
            "website": "http://syndication.mediafly.com/redirect/show/d581e9b773784df7a56f37e1138c037c",
            "description": "We're not talking dentistry here; FLOSS all about Free Libre Open Source Software. Join hosts Randal Schwartz and Leo Laporte every Saturday as they talk with the most interesting and important people in the Open Source and Free Software community.",
            "title": "FLOSS Weekly Video (large)",
+           "author": "Leo Laporte",
            "url": "http://feeds.twit.tv/floss_video_large",
            "position_last_week": 0,
            "subscribers_last_week": 50,

--- a/doc/api/reference/general.rst
+++ b/doc/api/reference/general.rst
@@ -102,6 +102,7 @@ JSON
        "website": "http://sixgun.org",
        "description": "The hardest-hitting Linux podcast around",
        "title": "Linux Outlaws",
+       "author": "Sixgun Productions",
        "url": "http://feeds.feedburner.com/linuxoutlaws",
        "position_last_week": 1,
        "subscribers_last_week": 1943,
@@ -124,6 +125,7 @@ XML
       <url>http://feeds.feedburner.com/linuxoutlaws</url>
       <website>http://sixgun.org</website>
       <mygpo_link>http://gpodder.net/podcast/11092</mygpo_link>
+      <author>Sixgun Productions</author>
       <description>The hardest-hitting Linux podcast around</description>
       <subscribers>1954</subscribers>
       <subscribers_last_week>1943</subscribers_last_week>

--- a/doc/api/reference/suggestions.rst
+++ b/doc/api/reference/suggestions.rst
@@ -29,6 +29,7 @@ Retrieve Suggested Podcasts
            "description": "Linux Geekdom",
            "subscribers": 0,
            "title": "Linux Geekdom",
+           "author": "aj@linuxgeekdom.com (A.J. Stringham)",
            "url": "http://www.linuxgeekdom.com/rssmp3.xml",
            "subscribers_last_week": 0,
            "logo_url": null
@@ -39,6 +40,7 @@ Retrieve Suggested Podcasts
            "description": "Going Linux",
            "subscribers": 571,
            "title": "Going Linux",
+           "author": "Larry Bushey",
            "url": "http://goinglinux.com/mp3podcast.xml",
            "subscribers_last_week": 571,
            "logo_url": "http://goinglinux.com/images/GoingLinux80.png"

--- a/mygpo/api/advanced/directory.py
+++ b/mygpo/api/advanced/directory.py
@@ -159,6 +159,7 @@ def podcast_data(obj, domain, scaled_logo_size=64):
     return {
         "url": url,
         "title": podcast.title,
+        "author": podcast.author,
         "description": podcast.description,
         "subscribers": subscribers,
         "subscribers_last_week": last_subscribers,

--- a/mygpo/api/templates/podcasts.xml
+++ b/mygpo/api/templates/podcasts.xml
@@ -5,6 +5,7 @@
   <url>{{ podcast.url }}</url>
   <website>{{ podcast.website|default:"" }}</website>
   <mygpo_link>{{ podcast.mygpo_link }}</mygpo_link>
+  <author>{{ podcast.author|default:"" }}</author>
   <description>{{ podcast.description|default:"" }}</description>
   <subscribers>{{ podcast.subscribers }}</subscribers>
   <subscribers_last_week>{{ podcast.subscribers_last_week }}</subscribers_last_week>


### PR DESCRIPTION
It would be great to have the author of podcasts returned in the API. I adapted the documentation and added the field to the API templates. Unfortunately, setting up the server is currently too much work for me, so this PR is **untested**. I would love if you could test and merge this, so [AntennaPod](https://github.com/AntennaPod/AntennaPod) can replace the URL in its search results with the authors, what should be a lot easier to understand for users (https://github.com/AntennaPod/AntennaPod/pull/3762).