### PR TITLE
OPML 2 support

### DIFF
--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -98,21 +98,23 @@ class Exporter(object):
                 title = channel.podcast.title
                 description = channel.podcast.description
                 url = channel.ref_url
+                outline.setAttribute('xmlUrl', url)
+                outline.setAttribute('description', description or '')
+                outline.setAttribute('type', 'rss')
             elif isinstance(channel, PodcastGroup):
                 title = channel.title
-                url = channel.podcast_set.first().url
                 for subchannel in channel.podcast_set.all():
                     outline.appendChild(create_outline(subchannel))
             else:
                 title = channel.title
                 description = channel.description
                 url = channel.url
+                outline.setAttribute('xmlUrl', url)
+                outline.setAttribute('description', description or '')
+                outline.setAttribute('type', 'rss')
 
             outline.setAttribute('title', title or '')
-            outline.setAttribute('description', description or '')
-            outline.setAttribute('text', title or description)
-            outline.setAttribute('xmlUrl', url)
-            outline.setAttribute('type', 'rss')
+            outline.setAttribute('text', title or '')
             return outline
 
         body = doc.createElement('body')

--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -3,7 +3,7 @@
 """OPML importer and exporter (based on gPodder's "opml" module)
 
 This module contains helper classes to import subscriptions from OPML files on
-the web and to export a list of podcast objects to valid OPML 1.1 files.
+the web and to export a list of podcast objects to valid OPML 2.0 files.
 """
 
 import os
@@ -58,7 +58,7 @@ class Importer(object):
 class Exporter(object):
     """
     Helper class to export a list of channel objects to a local file in OPML
-    1.1 format. See www.opml.org for the OPML specification.
+    2.0 format. See www.opml.org for the OPML specification.
     """
 
     def __init__(self, title='my.gpodder.org Subscriptions'):

--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -96,22 +96,20 @@ class Exporter(object):
 
             if isinstance(channel, SubscribedPodcast):
                 title = channel.podcast.title
-                description = channel.podcast.description
-                url = channel.ref_url
-                outline.setAttribute('xmlUrl', url)
-                outline.setAttribute('description', description or '')
+                outline.setAttribute('xmlUrl', channel.ref_url)
+                outline.setAttribute('description', channel.podcast.description or '')
                 outline.setAttribute('type', 'rss')
+                outline.setAttribute('htmlUrl', channel.podcast.link or '')
             elif isinstance(channel, PodcastGroup):
                 title = channel.title
                 for subchannel in channel.podcast_set.all():
                     outline.appendChild(create_outline(subchannel))
             else:
                 title = channel.title
-                description = channel.description
-                url = channel.url
-                outline.setAttribute('xmlUrl', url)
-                outline.setAttribute('description', description or '')
+                outline.setAttribute('xmlUrl', channel.url)
+                outline.setAttribute('description', channel.description or '')
                 outline.setAttribute('type', 'rss')
+                outline.setAttribute('htmlUrl', channel.podcast.link or '')
 
             outline.setAttribute('title', title or '')
             outline.setAttribute('text', title or '')

--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -108,7 +108,8 @@ class Exporter(object):
 
             outline = doc.createElement('outline')
             outline.setAttribute('title', title or '')
-            outline.setAttribute('text', description or '')
+            outline.setAttribute('description', description or '')
+            outline.setAttribute('text', title or description)
             outline.setAttribute('xmlUrl', url)
             outline.setAttribute('type', 'rss')
             return outline

--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -109,7 +109,7 @@ class Exporter(object):
                 outline.setAttribute('xmlUrl', channel.url)
                 outline.setAttribute('description', channel.description or '')
                 outline.setAttribute('type', 'rss')
-                outline.setAttribute('htmlUrl', channel.podcast.link or '')
+                outline.setAttribute('htmlUrl', channel.link or '')
 
             outline.setAttribute('title', title or '')
             outline.setAttribute('text', title or '')

--- a/mygpo/api/opml.py
+++ b/mygpo/api/opml.py
@@ -92,21 +92,22 @@ class Exporter(object):
             from mygpo.subscriptions.models import SubscribedPodcast
             from mygpo.podcasts.models import PodcastGroup
 
+            outline = doc.createElement('outline')
+
             if isinstance(channel, SubscribedPodcast):
                 title = channel.podcast.title
                 description = channel.podcast.description
                 url = channel.ref_url
             elif isinstance(channel, PodcastGroup):
                 title = channel.title
-                podcast = channel.podcast_set.first()
-                description = podcast.description
-                url = podcast.url
+                url = channel.podcast_set.first().url
+                for subchannel in channel.podcast_set.all():
+                    outline.appendChild(create_outline(subchannel))
             else:
                 title = channel.title
                 description = channel.description
                 url = channel.url
 
-            outline = doc.createElement('outline')
             outline.setAttribute('title', title or '')
             outline.setAttribute('description', description or '')
             outline.setAttribute('text', title or description)


### PR DESCRIPTION
Rebased from https://github.com/gpodder/mygpo/pull/35

- [X] Resolve conflict from rebased branch
- [X] PodcastGroup
- [X] htmlUrl

Exported OPML example:
```xml
<?xml version="1.0" encoding="utf-8"?>
<opml version="2.0">
    <head>
        <title>mygpo</title>
        <dateCreated>Thu, 06 Feb 2020 16:36:31 +0000</dateCreated>
    </head>
    <body>
        <outline description="Stories of the human heart. A candid, unscripted conversation between two people about what's really important in life: love, loss, family, friendship. When the world seems out of hand, tune in to _StoryCorps_ and be reminded of the things that matter most." htmlUrl="https://www.npr.org/storycorps" text="StoryCorps" title="StoryCorps" type="rss" xmlUrl="https://www.npr.org/rss/podcast.php?id=510200"/>
    </body>
</opml>

```
Format validated in Feedly.