### PR TITLE
Make publisher pages work for podcast stubs

### DIFF
--- a/mygpo/podcasts/models.py
+++ b/mygpo/podcasts/models.py
@@ -702,6 +702,9 @@ class Podcast(
 
     @property
     def next_update(self):
+        if not self.last_update:
+            return None
+
         interval = timedelta(hours=self.update_interval) * self.update_interval_factor
         return self.last_update + interval
 

--- a/mygpo/publisher/urls.py
+++ b/mygpo/publisher/urls.py
@@ -21,34 +21,6 @@ urlpatterns = [
         name='publisher-new-update-token',
     ),
     path(
-        'podcast/<slug:slug>/', views.podcast_slug, name='podcast-publisher-detail-slug'
-    ),
-    path(
-        'podcast/<slug:slug>/update',
-        views.update_podcast_slug,
-        name='podcast-publisher-update-slug',
-    ),
-    path(
-        'podcast/<slug:slug>/save',
-        views.save_podcast_slug,
-        name='podcast-publisher-save-slug',
-    ),
-    path(
-        'podcast/<slug:slug>/episodes',
-        views.episodes_slug,
-        name='podcast-publisher-episodes-slug',
-    ),
-    path(
-        'podcast/<slug:p_slug>/<slug:e_slug>',
-        views.episode_slug,
-        name='episode-publisher-detail-slug',
-    ),
-    path(
-        'podcast/<slug:p_slug>/<slug:e_slug>/set-slug',
-        views.update_episode_slug_slug,
-        name='publisher-set-episode-slug-slug',
-    ),
-    path(
         'podcast/<uuid:podcast_id>/',
         views.podcast_id,
         name='podcast-publisher-detail-id',
@@ -77,6 +49,34 @@ urlpatterns = [
         'podcast/<uuid:podcast_id>/<uuid:episode_id>/' 'set-slug',
         views.update_episode_slug_id,
         name='publisher-set-episode-slug-id',
+    ),
+    path(
+        'podcast/<slug:slug>/', views.podcast_slug, name='podcast-publisher-detail-slug'
+    ),
+    path(
+        'podcast/<slug:slug>/update',
+        views.update_podcast_slug,
+        name='podcast-publisher-update-slug',
+    ),
+    path(
+        'podcast/<slug:slug>/save',
+        views.save_podcast_slug,
+        name='podcast-publisher-save-slug',
+    ),
+    path(
+        'podcast/<slug:slug>/episodes',
+        views.episodes_slug,
+        name='podcast-publisher-episodes-slug',
+    ),
+    path(
+        'podcast/<slug:p_slug>/<slug:e_slug>',
+        views.episode_slug,
+        name='episode-publisher-detail-slug',
+    ),
+    path(
+        'podcast/<slug:p_slug>/<slug:e_slug>/set-slug',
+        views.update_episode_slug_slug,
+        name='publisher-set-episode-slug-slug',
     ),
     path('group/<slug:pg_slug>', views.group_slug, name='group-publisher-slug'),
     path('group/<slug:pg_slug>', views.group_id, name='group-publisher-id'),

--- a/mygpo/web/tests.py
+++ b/mygpo/web/tests.py
@@ -268,3 +268,43 @@ class PodcastLogoTests(TestCase):
             self.assertNotEqual(
                 list(response2.streaming_content), list(response3.streaming_content)
             )
+
+
+class PublisherPageTests(TestCase):
+    """ Test the publisher page """
+
+    @classmethod
+    def setUpTestData(self):
+        User = get_user_model()
+        self.user = User(username='web-test', email='web-test@example.com')
+        self.user.set_password('pwd')
+        self.user.is_staff = True
+        self.user.save()
+
+    def test_publisher_detail_slug(self):
+        # create a podcast with slug
+        podcast = Podcast.objects.get_or_create_for_url(
+            'http://example.com/podcast.rss'
+        ).object
+        slug = 'test'
+        podcast.set_slug(slug)
+
+        url = reverse('podcast-publisher-detail-slug', args=(slug,))
+
+        self.client.login(username='web-test', password='pwd')
+
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+
+    def test_publisher_detail_id(self):
+        # create a podcast with no slug
+        podcast = Podcast.objects.get_or_create_for_url(
+            'http://example.com/podcast2.rss'
+        ).object
+
+        url = reverse('podcast-publisher-detail-id', args=(podcast.id,))
+
+        self.client.login(username='web-test', password='pwd')
+
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Currently it's not possible to load the publisher page for a podcast stub because of the following:
* Podcast's `next_update` property raises an exception when `last_update` is `None`
* Patterns in `publisher/urls.py` are in the wrong order, slug patterns shadow uuid patterns

This PR fixes these. I'm not sure where I should put those test cases..