### PR TITLE
Make subscription tasks' arguments JSON serializable

### DIFF
--- a/mygpo/administration/tests.py
+++ b/mygpo/administration/tests.py
@@ -62,10 +62,10 @@ class SimpleTest(TestCase):
         device1 = Client.objects.create(user=user, uid='dev1', id=uuid.uuid1())
         device2 = Client.objects.create(user=user, uid='dev2', id=uuid.uuid1())
 
-        subscribe(p1, user, device1)
-        unsubscribe(p1, user, device1)
-        subscribe(p1, user, device1)
-        subscribe(p2, user, device2)
+        subscribe(p1.pk, user.pk, device1.uid)
+        unsubscribe(p1.pk, user.pk, device1.uid)
+        subscribe(p1.pk, user.pk, device1.uid)
+        subscribe(p2.pk, user.pk, device2.uid)
 
         action1 = EpisodeHistoryEntry.create_entry(user, e1, EpisodeHistoryEntry.PLAY)
         action3 = EpisodeHistoryEntry.create_entry(user, e3, EpisodeHistoryEntry.PLAY)

--- a/mygpo/api/legacy.py
+++ b/mygpo/api/legacy.py
@@ -54,11 +54,11 @@ def upload(request):
 
     for n in new:
         p = Podcast.objects.get_or_create_for_url(n).object
-        subscribe(p, user, dev)
+        subscribe(p.pk, user.pk, dev.uid)
 
     for r in rem:
         p = Podcast.objects.get_or_create_for_url(r).object
-        unsubscribe(p, user, dev)
+        unsubscribe(p.pk, user.pk, dev.uid)
 
     return HttpResponse('@SUCCESS', content_type='text/plain')
 

--- a/mygpo/api/simple.py
+++ b/mygpo/api/simple.py
@@ -223,11 +223,11 @@ def set_subscriptions(urls, user, device_uid, user_agent):
 
     remove_podcasts = Podcast.objects.filter(urls__url__in=rem)
     for podcast in remove_podcasts:
-        unsubscribe(podcast, user, device)
+        unsubscribe(podcast.pk, user.pk, device.uid)
 
     for url in new:
         podcast = Podcast.objects.get_or_create_for_url(url).object
-        subscribe(podcast, user, device, url)
+        subscribe(podcast.pk, user.pk, device.uid, url)
 
     # Only an empty response is a successful response
     return HttpResponse('', content_type='text/plain')

--- a/mygpo/api/subscriptions.py
+++ b/mygpo/api/subscriptions.py
@@ -85,11 +85,11 @@ class SubscriptionsAPI(APIView):
 
         for add_url in add_s:
             podcast = Podcast.objects.get_or_create_for_url(add_url).object
-            subscribe(podcast, user, device, add_url)
+            subscribe(podcast.pk, user.pk, device.uid, add_url)
 
         remove_podcasts = Podcast.objects.filter(urls__url__in=rem_s)
         for podcast in remove_podcasts:
-            unsubscribe(podcast, user, device)
+            unsubscribe(podcast.pk, user.pk, device.uid)
 
         return updated_urls
 

--- a/mygpo/podcasts/views/podcast.py
+++ b/mygpo/podcasts/views/podcast.py
@@ -266,7 +266,7 @@ def subscribe(request, podcast):
         for uid in device_uids:
             try:
                 device = request.user.client_set.get(uid=uid)
-                subscribe_podcast.delay(podcast, request.user, device)
+                subscribe_podcast.delay(podcast.pk, request.user.pk, device.uid)
 
             except Client.DoesNotExist as e:
                 messages.error(request, str(e))
@@ -284,7 +284,7 @@ def subscribe(request, podcast):
 def subscribe_all(request, podcast):
     """ subscribe all of the user's devices to the podcast """
     user = request.user
-    subscribe_podcast_all.delay(podcast, user)
+    subscribe_podcast_all.delay(podcast.pk, user.pk)
     return HttpResponseRedirect(get_podcast_link_target(podcast))
 
 
@@ -306,7 +306,7 @@ def unsubscribe(request, podcast, device_uid):
         return HttpResponseRedirect(return_to)
 
     try:
-        unsubscribe_podcast.delay(podcast, user, device)
+        unsubscribe_podcast.delay(podcast.pk, user.pk, device.uid)
     except SubscriptionException as e:
         logger.exception(
             'Web: %(username)s: could not unsubscribe from podcast %(podcast_url)s on device %(device_id)s'
@@ -326,7 +326,7 @@ def unsubscribe(request, podcast, device_uid):
 def unsubscribe_all(request, podcast):
     """ unsubscribe all of the user's devices from the podcast """
     user = request.user
-    unsubscribe_podcast_all.delay(podcast, user)
+    unsubscribe_podcast_all.delay(podcast.pk, user.pk)
     return HttpResponseRedirect(get_podcast_link_target(podcast))
 
 

--- a/mygpo/users/models.py
+++ b/mygpo/users/models.py
@@ -194,7 +194,7 @@ class SyncGroup(models.Model):
         for client in self.client_set.all():
             missing_podcasts = self.get_missing_podcasts(client, podcasts)
             for podcast in missing_podcasts:
-                subscribe.delay(podcast, self.user, client)
+                subscribe.delay(podcast.pk, self.user.pk, client.uid)
 
     def get_subscribed_podcasts(self):
         return Podcast.objects.filter(subscription__client__sync_group=self)

--- a/mygpo/users/tests.py
+++ b/mygpo/users/tests.py
@@ -78,7 +78,7 @@ class UnsubscribeMergeTests(TestCase):
         self.device = get_device(self.user, 'dev', '')
 
     def test_merge_podcasts(self):
-        subscribe(self.podcast2, self.user, self.device)
+        subscribe(self.podcast2.pk, self.user.pk, self.device.uid)
 
         # merge podcast2 into podcast1
         pm = PodcastMerger([self.podcast1, self.podcast2], Counter(), [])
@@ -86,7 +86,7 @@ class UnsubscribeMergeTests(TestCase):
 
         # get podcast for URL of podcast2 and unsubscribe from it
         p = Podcast.objects.get(urls__url=self.P2_URL)
-        unsubscribe(p, self.user, self.device)
+        unsubscribe(p.pk, self.user.pk, self.device.uid)
 
         subscriptions = Podcast.objects.filter(subscription__user=self.user)
         self.assertEqual(0, len(subscriptions))


### PR DESCRIPTION
Asynchronously calling subscription tasks is currently broken on master (this includes subscribing to podcasts via the web interface).

This is since https://github.com/gpodder/mygpo/pull/24 was merged. Celery 4 uses `json` as the default task serializer, so all parameters need to be JSON serializable. Subscription tasks have arguments that aren't, thus an exception is thrown when they're scheduled.

This is my attempt at fixing this by changing task arguments so they use primary keys.