### PR TITLE
Use HTTPS URIs in README, fix query params in RST for Directory API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ mygpo is licensed under the GNU Affero General Public License Version 3. See fil
 
 Installation
 ------------
-See the [installation instructions](http://gpoddernet.readthedocs.io/en/latest/dev/installation.html) for details.
+See the [installation instructions](https://gpoddernet.readthedocs.io/en/latest/dev/installation.html) for details.
 
 
 Bugs
@@ -21,7 +21,7 @@ Please report bugs in the [GitHub issue tracker](https://github.com/gpodder/mygp
 
 Contributing
 ------------
-gpodder.net is an open source project and your contributions are wanted and appreciated.  To get started please see the [developer documentation](http://gpoddernet.readthedocs.io/en/latest/dev/index.html).
+gpodder.net is an open source project and your contributions are wanted and appreciated.  To get started please see the [developer documentation](https://gpoddernet.readthedocs.io/en/latest/dev/index.html).
 
 Slack
 ------------
@@ -36,7 +36,7 @@ gpodder.org related issues are discussed on the [gPodder Mailing List](https://g
 
 Documentation
 -------------
-Documentation, especially for the API, is stored in the [**doc** folder](https://github.com/gpodder/mygpo/tree/master/doc) and can be read on [ReadTheDocs](http://gpoddernet.readthedocs.io/en/latest/index.html).
+Documentation, especially for the API, is stored in the [**doc** folder](https://github.com/gpodder/mygpo/tree/master/doc) and can be read on [ReadTheDocs](https://gpoddernet.readthedocs.io/en/latest/index.html).
 
 
 Name (Why mygpo?)

--- a/doc/api/reference/directory.rst
+++ b/doc/api/reference/directory.rst
@@ -116,7 +116,7 @@ Retrieve Podcast Data
          "logo_url": "http://www.coverville.com/art/coverville_iTunes300.jpg"
         }
 
-    ::query url: the feed URL of the podcast
+    :query url: the feed URL of the podcast
 
 
 .. _api-episode-data:
@@ -149,8 +149,8 @@ Retrieve Episode Data
          "mygpo_link": "http://gpodder.net/episode/1046492"
         }
 
-    ::query podcast: feed URL of the podcast to which the episode belongs
-    ::query url: media URL of the episode
+    :query podcast: feed URL of the podcast to which the episode belongs
+    :query url: media URL of the episode
 
 
 Podcast Toplist


### PR DESCRIPTION
This is a small update (IMHO) to gpodder.net documentation.

I noticed that links to Read the Docs used insecure HTTP URIs, whereas HTTPS is available. The change to the README updates these links to HTTPS.

In the [Directory API documentation](https://gpoddernet.readthedocs.io/en/latest/api/reference/directory.html) I noticed broken descriptions of query parameters in two endpoints, while other endpoints had correct descriptions.
Based on the working descriptions, I changed `::query` to `:query` in the ReStructuredText for the Directory API.