### PR TITLE
Fixed editing PodcastGroup entity in admin interface

### DIFF
--- a/mygpo/podcasts/admin.py
+++ b/mygpo/podcasts/admin.py
@@ -74,7 +74,7 @@ class PodcastInline(AdminLinkInline):
 
     can_delete = False
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         """Podcasts must be created and then added to the group"""
         return False
 


### PR DESCRIPTION
Trying to add or edit a PodcastGroup entity in the admin interface makes Django error out with a TypeError. The exception is thrown for the PodcastInline admin class.

```
has_add_permission() takes 2 positional arguments but 3 were given
```

The following change fixes the issue so a PodcastGroup can be edited in the admin interface.