### PR TITLE
Display 'Passwords do not match' error for registration form

### DIFF
--- a/mygpo/users/views/registration.py
+++ b/mygpo/users/views/registration.py
@@ -90,6 +90,13 @@ class RegistrationView(FormView):
         send_activation_email(user, self.request)
         return super(RegistrationView, self).form_valid(form)
 
+    def form_invalid(self, form):
+        """Populate session messages if form validation fails"""
+        for key, errors in form.errors.items():
+            messages.error(self.request, "; ".join([error for error in errors]))
+
+        return super().form_invalid(form)
+
     @transaction.atomic
     def create_user(self, form):
         User = get_user_model()


### PR DESCRIPTION
Maybe not the best approach for getting the "Passwords do not match" error to show up for the registration view but it works. As it was, the validation error message would not show up on the rendered page when password validation failed. FormView.form_invalid is used to insert the form error message into the session messages so it will show up if registration form validation fails.