### PR TITLE
Fix typo for french word "Accueil" (Home)

### DIFF
--- a/mygpo/locale/fr/LC_MESSAGES/django.po
+++ b/mygpo/locale/fr/LC_MESSAGES/django.po
@@ -2728,7 +2728,7 @@ msgstr "Épisode inconnu"
 
 #: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
 msgid "Home"
-msgstr "Acceuil"
+msgstr "Accueil"
 
 #: mygpo/web/templatetags/menu.py:30
 msgid "Help"


### PR DESCRIPTION
Fix a common french typo