### PR TITLE
Pinning Django to 3.2 (LTS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ notebooks/
 
 .cache
 .pytest_cache
+
+# Visual Studio Code files
+.vscode

--- a/mygpo/utils.py
+++ b/mygpo/utils.py
@@ -243,7 +243,7 @@ def longest_substr(strings):
     return substr
 
 
-def file_hash(f, h=hashlib.md5, block_size=2 ** 20):
+def file_hash(f, h=hashlib.md5, block_size=2**20):
     """returns the hash of the contents of a file"""
     f_hash = h()
     while True:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ flake8
 django-debug-toolbar==3.2.2
 django-extensions
 jupyter
-black==21.9b0
+black==22.6

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,5 +4,5 @@ pytest>=4.6
 pytest-django
 pytest-cov
 responses==0.14.0
-black==21.9b0
+black==22.6
 openapi-spec-validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django<3.3
-celery==5.1.2
+Django==3.2
+celery==5.2.7
 Babel==2.9.1
 Pillow==8.4.0
-celery[redis]==5.1.2
+celery[redis]==5.2.7
 dj-database-url==0.5.0
 django-redis-sessions==0.6.2
 python-memcached==1.59


### PR DESCRIPTION
This commit also updates versions of celery and black.