### PR TITLE
replace dead links

### DIFF
--- a/doc/user/clients.rst
+++ b/doc/user/clients.rst
@@ -14,7 +14,7 @@ Name                  Status      gpodder.net features                          
 `AntennaPod`_         Active      Directory, Search, Subscription sync, Episode Action sync   GPL 3     `Synchronisation between devices`_
 `Escapepod`_          Active      Search                                                      MIT
 `Listen Up Free`_     Active      sync, subscription, search
-`Podcast Addict`_     Active      none                                                                  `Podcast Addict export script`_
+`Podcast Addict`_     Active      none
 `Podkicker`_          Active      none
 `Podax`_              Abandoned   Subscription sync                                           BSD
 `Volksempfänger`_     Abandoned   Podcast search                                              ISC
@@ -140,7 +140,7 @@ Nokia Podcasting       -       Subscription service    GPL         `Podcasting D
 .. _Detlef Gpodderson: https://play.google.com/apps/testing/at.ac.tuwien.detlef
 .. _Detlef Repository: https://github.com/gpodder/detlef
 .. _AntennaPod: http://antennapod.org/
-.. _Synchronisation between devices: https://antennapod.org/documentation/general/gpodder
+.. _Synchronisation between devices: https://antennapod.org/documentation/general/synchronization
 .. _Escapepod: https://github.com/y20k/escapepod
 .. _gpodroid: https://play.google.com/store/apps/details?id=com.unitedcoders.android.gpodroid
 .. _gpodroid Repository: https://github.com/gpodder/GpodRoid
@@ -149,7 +149,6 @@ Nokia Podcasting       -       Subscription service    GPL         `Podcasting D
 .. _Feed Farmer: https://play.google.com/store/apps/details?id=com.escape.FeedFarmer&hl=en
 .. _Podcatcher Deluxe: http://www.podcatcher-deluxe.com/
 .. _Podcast Addict: https://play.google.com/store/apps/details?id=com.bambuna.podcastaddict
-.. _Podcast Addict export script: http://www.mameau.com/gpodder-podcast-import-script/
 .. _Podkicker: https://play.google.com/store/apps/details?id=ait.podka&hl=de
 .. _SoundWaves: https://github.com/bottiger/SoundWaves
 .. _Mopidy-Podcast-GPodder: http://github.com/tkem/mopidy-podcast-gpodder/


### PR DESCRIPTION
I stumbled upon two dead links:

- ~~Antennapod: There is a fitting page. Probably just the path changed.~~
- Podcast Addict: The link was leading to a personal page. I couldn't find a replacement and thus just removed the link.