### PR TITLE
openAPI: fix method summary

### DIFF
--- a/mygpo/api/openapi.yaml
+++ b/mygpo/api/openapi.yaml
@@ -496,7 +496,7 @@ paths:
     get:
       tags:
       - "Subscriptions"
-      summary: "Update Device Data"
+      summary: "Get Subscriptions of Device"
       parameters:
       - name: "username"
         in: "path"
@@ -1013,7 +1013,7 @@ components:
           description: "Time in seconds for which the values in this file can be considered valid."
     Format:
       type: "string"
-      enum: 
+      enum:
       - "json"
       - "xml"
       - "opml"


### PR DESCRIPTION
hi there! according to [the docs](https://gpoddernet.readthedocs.io/en/latest/api/reference/subscriptions.html#get-subscriptions-of-device), the method to get subscriptions by device should be updated in the openAPI summary - right now it is confusing, because the summary indicates something about `updating`, which doesn't seem to be correct.

thanks!