### PR TITLE
hack to dump traffic for analysis

### DIFF
--- a/mygpo/dumping.py
+++ b/mygpo/dumping.py
@@ -8,6 +8,7 @@ import time
 import json
 import logging
 import os
+import traceback
 
 logger = logging.getLogger(__name__)
 
@@ -29,45 +30,77 @@ class DumpingMiddleware:
                 "path": request.get_full_path(),
             }
 
-            req_body = None
-            if request.content_type == "application/json":
-                try:
-                    # parse as json because it's easier to query later
-                    req_body = (
-                        json.loads(request.body.decode("utf-8")) if request.body else {}
-                    )
-                except ValueError:
-                    req_body = None
-            if req_body is None:
-                req_body = (
-                    request.body.decode("utf-8", errors="replace")
-                    if request.body
-                    else ""
-                )
-            log_data["request_body"] = req_body
+            log_data["request_body"] = self._parse_request_body(request)
 
-        # request passes on to controller
-        response = self.get_response(request)
+            response = self.get_response(request)
 
-        if "/api/" in str(request.get_full_path()):
-            # add runtime to our log_data
-            if response and response["content-type"] == "application/json":
-                response_body = json.loads(response.content.decode("utf-8"))
+            if response:
+                log_data["status_code"] = response.status_code
+                log_data["response_headers"] = {
+                    k: str(v) for k, v in response.headers.items()
+                }
+                if response["content-type"] == "application/json":
+                    response_body = json.loads(response.content.decode("utf-8"))
+                else:
+                    try:
+                        response_body = response.content.decode("utf-8")
+                    except Exception:
+                        response_body = (
+                            f"Unable to decode {len(response.content)} len response"
+                        )
                 log_data["response_body"] = response_body
+
             log_data["run_time"] = time.monotonic() - start_time
 
-            # dump data to disk in mygpo_dump/<first 2 letters in user id>/<user id>/<datetime>_<unique suffix>
-            if request.user:
-                dirname = os.path.join(
-                    DUMPING_FOLDER, str(request.user.id)[:2], str(request.user.id)
-                )
-            else:
-                dirname = os.path.join(DUMPING_FOLDER, "unknown")
-
-            os.makedirs(dirname, exist_ok=True)
-            filename = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f_")
-            fd, filepath = tempfile.mkstemp(prefix=filename, dir=dirname)
-            with open(fd, "w", encoding="utf-8") as f:
-                f.write(json.dumps(log_data))
+            self._save_data(request, log_data)
+        else:
+            response = self.get_response(request)
 
         return response
+
+    def process_exception(self, request, exception):
+        if "/api/" in str(request.get_full_path()):
+            log_data = {
+                "user_agent": request.headers["User-Agent"],
+                "method": request.method,
+                "path": request.get_full_path(),
+            }
+
+            log_data["request_body"] = self._parse_request_body(request)
+
+            log_data["exception"] = traceback.format_exception(exception)
+
+            self.save_data(request, log_data)
+        return None  # will trigger the default django exception handling
+
+    def _parse_request_body(self, request):
+        req_body = None
+        if request.content_type == "application/json":
+            try:
+                # parse as json because it's easier to query later
+                req_body = (
+                    json.loads(request.body.decode("utf-8")) if request.body else {}
+                )
+            except ValueError:
+                req_body = None
+        if req_body is None:
+            req_body = (
+                request.body.decode("utf-8", errors="replace") if request.body else ""
+            )
+        return req_body
+
+    def _save_data(self, request, log_data):
+
+        # dump data to disk in mygpo_dump/<first 2 letters in user id>/<user id>/<datetime>_<unique suffix>
+        if request.user:
+            dirname = os.path.join(
+                DUMPING_FOLDER, str(request.user.id)[:2], str(request.user.id)
+            )
+        else:
+            dirname = os.path.join(DUMPING_FOLDER, "unknown")
+
+        os.makedirs(dirname, exist_ok=True)
+        filename = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f_")
+        fd, filepath = tempfile.mkstemp(prefix=filename, dir=dirname)
+        with open(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(log_data))

--- a/mygpo/dumping.py
+++ b/mygpo/dumping.py
@@ -1,0 +1,73 @@
+"""
+Dump `*/api/*` requests and responses to disk
+"""
+
+import datetime
+import tempfile
+import time
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+DUMPING_FOLDER = "mygpo_dump"
+
+
+class DumpingMiddleware:
+    """Request/Response Logging Middleware."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if "/api/" in str(request.get_full_path()):
+            start_time = time.monotonic()
+            log_data = {
+                "user_agent": request.headers["User-Agent"],
+                "method": request.method,
+                "path": request.get_full_path(),
+            }
+
+            req_body = None
+            if request.content_type == "application/json":
+                try:
+                    # parse as json because it's easier to query later
+                    req_body = (
+                        json.loads(request.body.decode("utf-8")) if request.body else {}
+                    )
+                except ValueError:
+                    req_body = None
+            if req_body is None:
+                req_body = (
+                    request.body.decode("utf-8", errors="replace")
+                    if request.body
+                    else ""
+                )
+            log_data["request_body"] = req_body
+
+        # request passes on to controller
+        response = self.get_response(request)
+
+        if "/api/" in str(request.get_full_path()):
+            # add runtime to our log_data
+            if response and response["content-type"] == "application/json":
+                response_body = json.loads(response.content.decode("utf-8"))
+                log_data["response_body"] = response_body
+            log_data["run_time"] = time.monotonic() - start_time
+
+            # dump data to disk in mygpo_dump/<first 2 letters in user id>/<user id>/<datetime>_<unique suffix>
+            if request.user:
+                dirname = os.path.join(
+                    DUMPING_FOLDER, str(request.user.id)[:2], str(request.user.id)
+                )
+            else:
+                dirname = os.path.join(DUMPING_FOLDER, "unknown")
+
+            os.makedirs(dirname, exist_ok=True)
+            filename = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f_")
+            fd, filepath = tempfile.mkstemp(prefix=filename, dir=dirname)
+            with open(fd, "w", encoding="utf-8") as f:
+                f.write(json.dumps(log_data))
+
+        return response

--- a/mygpo/podcasts/models.py
+++ b/mygpo/podcasts/models.py
@@ -861,6 +861,9 @@ class Episode(
 
         return int(match.group(1))
 
+    def __str__(self):
+        return self.title or f"NOTITLE<{self.url if self.url else self.pk}>"
+
 
 class Tag(models.Model):
     """Tags any kind of Model

--- a/mygpo/settings.py
+++ b/mygpo/settings.py
@@ -34,6 +34,8 @@ def get_intOrNone(name, default):
 
 DEBUG = get_bool("DEBUG", False)
 
+DUMP_TRAFFIC = get_bool("DUMP_TRAFFIC", False)
+
 ADMINS = re.findall(r"\s*([^<]+) <([^>]+)>\s*", os.getenv("ADMINS", ""))
 
 MANAGERS = ADMINS
@@ -210,6 +212,8 @@ try:
 except ImportError:
     pass
 
+if DUMP_TRAFFIC:
+    MIDDLEWARE += ["mygpo.dumping.DumpingMiddleware"]
 
 ACCOUNT_ACTIVATION_DAYS = int(os.getenv("ACCOUNT_ACTIVATION_DAYS", 7))
 


### PR DESCRIPTION
if a new setting `DUMP_TRAFFIC` is true, will dump api requests/responses to a `mygpo_dump` folder, for investigation.

Dump files must be handled cautiously because they contain user information (no password but subscriptions, play history, etc.).
Also keep activated for a short time only, to not saturate server storage (about 50MB per day).