### PR TITLE
Remove reference to gpodder@freelists.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ Join our Slack channel: [gpodder-net.slack.com](https://gpodder-net.slack.com/)
 
 [Invitation link](https://join.slack.com/t/gpodder-net/shared_invite/zt-aaiagl5i-uZeqVR8w1Yf_G~9rhktRfw)
 
-Mailing List
-------------
-gpodder.org related issues are discussed on the [gPodder Mailing List](https://gpodder.github.io/docs/mailing-list.html).
-
-
 Documentation
 -------------
 Documentation, especially for the API, is stored in the [**doc** folder](https://github.com/gpodder/mygpo/tree/master/doc) and can be read on [ReadTheDocs](https://gpoddernet.readthedocs.io/en/latest/index.html).

--- a/doc/api/integration.rst
+++ b/doc/api/integration.rst
@@ -10,7 +10,7 @@ applications. It describes good practice and points out caveats.
 General
 -------
 
-* The `Mailing List <https://gpodder.github.io/docs/mailing-list.html>`_ is the right
+* The `Issue Tracker <https://github.com/gpodder/mygpo/issues>`_ is the right
   place to ask questions
 
 * Consult the :ref:`api-reference` for available functionality.
@@ -34,7 +34,7 @@ Implementation
 
 * Try to keep the requests to the API to a sensible limit. There are no hard
   limit, please judge for yourself what is necessary in your case. Please ask
-  on the mailing list if unsure. Your client might get blocked if it
+  on the issue tracker if unsure. Your client might get blocked if it
   misbehaves.
 
 * Your client should send a useful User-Agent header. We might block clients

--- a/doc/api/reference/events.rst
+++ b/doc/api/reference/events.rst
@@ -5,7 +5,7 @@ The episode actions API is used to synchronize episode-related events between
 individual devices. Clients can send and store events on the webservice which
 makes it available to other clients. The following types of actions are
 currently accepted by the API: download, play, delete, new. Additional types
-can be requested on the Mailing List.
+can be requested on Github.
 
 Example use cases
 

--- a/mygpo/locale/br/LC_MESSAGES/django.po
+++ b/mygpo/locale/br/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2018-06-20 06:29+0000\n"
 "Last-Translator: Irriep Nala Novram <allannkorh@yahoo.fr>, 2019\n"
 "Language-Team: Breton (https://www.transifex.com/yaron/teams/87581/br/)\n"
@@ -20,10 +20,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=5; plural=((n%10 == 1) && (n%100 != 11) && (n%100 !"
-"=71) && (n%100 !=91) ? 0 :(n%10 == 2) && (n%100 != 12) && (n%100 !=72) && (n"
-"%100 !=92) ? 1 :(n%10 ==3 || n%10==4 || n%10==9) && (n%100 < 10 || n% 100 > "
-"19) && (n%100 < 70 || n%100 > 79) && (n%100 < 90 || n%100 > 99) ? 2 :(n != 0 "
-"&& n % 1000000 == 0) ? 3 : 4);\n"
+"=71) && (n%100 !=91) ? 0 :(n%10 == 2) && (n%100 != 12) && (n%100 !=72) && "
+"(n%100 !=92) ? 1 :(n%10 ==3 || n%10==4 || n%10==9) && (n%100 < 10 || n% 100 "
+"> 19) && (n%100 < 70 || n%100 > 79) && (n%100 < 90 || n%100 > 99) ? 2 :(n != "
+"0 && n % 1000000 == 0) ? 3 : 4);\n"
 
 #: mygpo/administration/templates/admin/activate-user.html:9
 #: mygpo/administration/templates/admin/activate-user.html:12
@@ -34,7 +34,7 @@ msgstr "Enaouiñ an implijer"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Anv-implijer"
 
@@ -160,7 +160,7 @@ msgstr "Lodennoù labour Celery programmet"
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr "Aotreadurioù an embanner"
 
@@ -197,7 +197,11 @@ msgstr "M'ho peus goulennoù kit da welet %(url)s"
 msgid "Merge Podcasts and Episodes"
 msgstr "Kendeuziñ ar podskignoù hag ar rannoù"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -288,25 +292,37 @@ msgstr "Freskaat"
 msgid "User-Agent"
 msgstr "Implijer-Ajant"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "Podskign ebet gant an URL {url}"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr "Implijer ebet kavet"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr "Impllijer {username} ({email}) enaouet"
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} is already activated"
+msgstr "Impllijer {username} ({email}) enaouet"
+
+#: mygpo/administration/views.py:383
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} data has been archived."
+msgstr "Impllijer {username} ({email}) enaouet"
+
+#: mygpo/administration/views.py:389
 #, fuzzy, python-brace-format
 #| msgid "User {username} ({email}) activated"
 msgid "Email for {username} ({email}) resent"
@@ -389,11 +405,11 @@ msgstr "Kavlec'h ar podskignoù"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"%(listtitle)s <span class=\"by-user\">gant <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">gant <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -452,8 +468,8 @@ msgstr "Gwelet al lisañs"
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podskign"
 
@@ -476,14 +492,14 @@ msgid "Podcasts with License Information"
 msgstr "Podskignoù gant titouroù diwar-benn al lisañs"
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr "Lisañs"
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr "Podskignoù"
 
@@ -530,7 +546,7 @@ msgid "OK"
 msgstr "Mat eo"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr "Podskign a vank"
 
@@ -563,7 +579,7 @@ msgstr "Podskign paeroniañ"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr "Listennadoù podskignoù"
 
@@ -579,6 +595,7 @@ msgstr "Implijer"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "Pellgargañ"
 
@@ -597,8 +614,8 @@ msgstr "Krouit ul listenn podskignoù war ur sujed a blij deoc'h"
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Klask"
 
@@ -632,20 +649,20 @@ msgstr "Listenn ar re wellañ"
 msgid "Client Access"
 msgstr "Moned ar pratik"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr "%d a bodskignoù ouzhpennet"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -666,7 +683,7 @@ msgid "Action"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr ""
 
@@ -676,7 +693,7 @@ msgstr ""
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr "Roll-istor ar c'houmanantoù"
@@ -710,7 +727,7 @@ msgstr "Bremañ"
 msgid "Earlier"
 msgstr "Abretoc'h"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -789,16 +806,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -838,24 +855,24 @@ msgstr ""
 msgid "Episode History"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr ""
@@ -918,9 +935,9 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr ""
 
@@ -977,18 +994,6 @@ msgid ""
 "advertisement period."
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr ""
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr ""
@@ -1009,7 +1014,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1028,7 +1033,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr ""
 
@@ -1110,8 +1115,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/info.html:27
@@ -1191,8 +1196,8 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1247,8 +1252,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1267,21 +1272,21 @@ msgstr ""
 msgid "Show Group Stats"
 msgstr ""
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1350,8 +1355,8 @@ msgstr ""
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr ""
 
@@ -1366,7 +1371,7 @@ msgid "User Page"
 msgstr ""
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr ""
 
@@ -1479,9 +1484,9 @@ msgstr ""
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1490,22 +1495,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr ""
@@ -1523,27 +1528,27 @@ msgstr ""
 msgid "No Suggestions Yet"
 msgstr ""
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr ""
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr ""
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr ""
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr ""
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr ""
 
@@ -1578,9 +1583,9 @@ msgid "You are already registered."
 msgstr ""
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr ""
 
@@ -1656,125 +1661,115 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr ""
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr ""
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+msgid "Your data has been archived."
+msgstr ""
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr ""
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr ""
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr ""
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr ""
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr ""
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr ""
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr ""
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr ""
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr ""
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr ""
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr ""
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr ""
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr ""
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr ""
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr ""
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr ""
 
@@ -1816,110 +1811,97 @@ msgstr ""
 msgid "Disconnect"
 msgstr ""
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr ""
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr ""
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr ""
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr ""
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr ""
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr ""
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr ""
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -1943,15 +1925,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -1979,7 +1959,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr ""
 
@@ -1995,18 +1975,17 @@ msgstr ""
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2095,7 +2074,7 @@ msgid "Thanks"
 msgstr ""
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2214,9 +2193,9 @@ msgstr ""
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2232,7 +2211,7 @@ msgid "Delete Permanently"
 msgstr ""
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr ""
 
@@ -2256,15 +2235,15 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
 
 #: mygpo/web/templates/password_reset.html:4
@@ -2278,8 +2257,8 @@ msgstr ""
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 
 #: mygpo/web/templates/password_reset_failed.html:4
@@ -2335,7 +2314,7 @@ msgstr ""
 msgid "Make Public"
 msgstr ""
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr ""
 
@@ -2367,6 +2346,17 @@ msgid ""
 "Because we display names after we have fetched the information from the feed "
 "-- and this may take some time. Until this is completed, the podcast will "
 "simply be called this way."
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Activate User"
+msgid "Archived User"
+msgstr "Enaouiñ an implijer"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
 msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
@@ -2514,47 +2504,51 @@ msgstr ""
 msgid "Unknown Episode"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr ""
 
@@ -2568,7 +2562,7 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
@@ -2578,7 +2572,7 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
@@ -2588,7 +2582,7 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
@@ -2598,6 +2592,6 @@ msgstr[2] ""
 msgstr[3] ""
 msgstr[4] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr ""

--- a/mygpo/locale/de/LC_MESSAGES/django.po
+++ b/mygpo/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2010-07-16 08:51+0200\n"
 "Last-Translator: Stefan Koegl <stefan@skoegl.net>\n"
 "Language-Team: DE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgstr "Wiederherstellen"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Benutzername"
 
@@ -160,7 +160,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 #, fuzzy
 #| msgid "Publisher Pages"
 msgid "Publisher Permissions"
@@ -203,7 +203,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr "Podcast / Episode"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -299,26 +303,36 @@ msgstr ""
 msgid "User-Agent"
 msgstr ""
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr ""
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 #, fuzzy
 msgid "No user found"
 msgstr "Nicht gefunden"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -401,8 +415,8 @@ msgstr "Podcast-Verzeichnis"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
 
 #: mygpo/directory/templates/directory.html:46
@@ -468,8 +482,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podcast"
 
@@ -493,14 +507,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 #, fuzzy
 msgid "Podcasts"
 msgstr "Podcast"
@@ -549,7 +563,7 @@ msgid "OK"
 msgstr "OK"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 #, fuzzy
 msgid "Missing Podcast"
 msgstr "Vorgeschlagene Podcasts"
@@ -583,7 +597,7 @@ msgstr "Vorgeschlagene Podcasts"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 #, fuzzy
 msgid "Podcast Lists"
 msgstr "Podcast-Topliste"
@@ -602,6 +616,7 @@ msgstr "Benutzername"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "herunterladen"
 
@@ -620,8 +635,8 @@ msgstr ""
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Suchen"
 
@@ -655,20 +670,20 @@ msgstr "Topliste"
 msgid "Client Access"
 msgstr ""
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, fuzzy, python-format
 msgid "%d podcasts added"
 msgstr "Podcasts"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Verlauf"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 #, fuzzy
@@ -691,7 +706,7 @@ msgid "Action"
 msgstr "Aktivität"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Geräte"
 
@@ -701,7 +716,7 @@ msgstr "Hinzufügen"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 #, fuzzy
 msgid "Subscription History"
@@ -737,7 +752,7 @@ msgstr "Nein"
 msgid "Earlier"
 msgstr ""
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -819,16 +834,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -873,24 +888,24 @@ msgstr "Favorit"
 msgid "Episode History"
 msgstr "Dein Episoden Verlauf"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Unbenannter Podcast"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 #, fuzzy
 msgid "subscribers"
@@ -964,9 +979,9 @@ msgstr "Ändere YOUR_ADRESS in die Adresse deines Podcastes um."
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "Werben"
 
@@ -1037,21 +1052,6 @@ msgstr ""
 "3000 Personen abgerufen (also <strong>6000 Personen</strong> insgesamt), die "
 "aktiv nach interessanten Podcasts suchen."
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "Werbung starten"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"Wenn Sie Fragen haben oder Ihre Werbung auf %(sitename)s schalten möchten, "
-"wenden Sie sich bitte an <a href=\"mailto:stefan@gpodder.net"
-"\">stefan@gpodder.net</a>. Die Bezahlung erfolgt einfach per Paypal."
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "Namenlose Episode"
@@ -1074,7 +1074,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1094,7 +1094,7 @@ msgstr "Zurück zum Podcast"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Episoden"
 
@@ -1188,8 +1188,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, fuzzy, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 "Details über die Werbe-Einschaltungen finden Sie auf der <a href=\"/"
 "publisher/advertise\">Werbe-Seite</a>."
@@ -1290,8 +1290,8 @@ msgstr ""
 msgid "Update now"
 msgstr "Daten aus dem Feed holen"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1346,8 +1346,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1367,23 +1367,23 @@ msgstr "Link zu"
 msgid "Show Group Stats"
 msgstr "Statistiken für alle Podcasts in der Gruppe anzeigen"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 #, fuzzy
 msgid "Data updated"
 msgstr "Geräte-Liste"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 #, fuzzy
 msgid "Publisher token updated"
 msgstr "Bewerben Sie Ihren Podcast"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1468,8 +1468,8 @@ msgstr "Teilen"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Abonnements"
 
@@ -1486,7 +1486,7 @@ msgid "User Page"
 msgstr "Benutzername"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -1604,9 +1604,9 @@ msgstr "%(listener_count)s Hörer"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1616,22 +1616,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr "herunterladen"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, fuzzy, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "%(username)ss Podcast-Abos"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, fuzzy, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "Abonniere %(podcasttitle)s"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, fuzzy, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "Abonniere %(podcasttitle)s"
@@ -1651,27 +1651,27 @@ msgstr "Kein Interesse"
 msgid "No Suggestions Yet"
 msgstr "Empfehlungen"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Desktop"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Laptop"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Handy"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Server"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Andere"
 
@@ -1712,9 +1712,9 @@ msgid "You are already registered."
 msgstr "Sie sind bereits registriert. "
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Registrieren"
 
@@ -1798,58 +1798,70 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 #, fuzzy
 #| msgid "Your account already has been activated. Go ahead and log in."
 msgid "Your user has been activated. You can log in now."
 msgstr "Dein Konto wurde aktiviert! Viel Spaß mit my.gpodder.org"
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "Der Benutzer existiert nicht."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your settings have been saved."
+msgid "Your data has been archived."
+msgstr "Ihre Einstellungen wurden gespeichert."
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "Dein Konto wurde aktiviert! Viel Spaß mit my.gpodder.org"
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 "Oops! Irgendetwas ist schiefgegangen. Bitte überprüfen Sie die eingegebenen "
 "Daten. "
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 #, fuzzy
 msgid "Your account has been disconnected"
 msgstr "Ihr Account wurde gelöscht"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 #, fuzzy
 msgid "Username missing"
 msgstr "Benutzername"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 #, fuzzy
 msgid "Password missing"
 msgstr "Ihr Passwort wurde zurückgesetzt"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Benutzername oder Passwort falsch"
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 #, fuzzy
 #| msgid "Please activate your account first."
 msgid ""
@@ -1857,78 +1869,57 @@ msgid ""
 "email"
 msgstr "Ihr Account muss zuerst aktiviert werden."
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-#, fuzzy
-msgid "Login failed."
-msgstr "Anmelden"
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "Deine E-Mail-Adresse"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Aktuelles Passwort"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "Neues Passwort bestätigen"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Name"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Typ"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "Geräte-ID"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 #, fuzzy
 #| msgid "Device"
 msgid "ID on device"
 msgstr "Geräte"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "Diese Abo in die Statistiken aufnehmen"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Kein Gerät ausgewählt"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Entweder Benutzername"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "oder Email-Adresse eingeben"
 
@@ -1972,112 +1963,99 @@ msgstr ""
 msgid "Disconnect"
 msgstr "Entdecken"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "Account"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Anmelden"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Entdecken"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "Verzeichnis"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 #, fuzzy
 msgid "Questions"
 msgstr "Empfehlungen"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "Programm-Bibliotheken"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 #, fuzzy
 msgid "Publish"
 msgstr "Publisher"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -2102,15 +2080,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2144,7 +2120,7 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nein"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "Übersicht"
 
@@ -2160,18 +2136,17 @@ msgstr "Aktuelle Episoden"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2268,7 +2243,7 @@ msgid "Thanks"
 msgstr "Danke"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2398,9 +2373,9 @@ msgstr "Synchronisieren"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2417,7 +2392,7 @@ msgid "Delete Permanently"
 msgstr "Account löschen"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "Lieblings-Episoden"
 
@@ -2442,18 +2417,18 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "Meine Tags"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"Sie haben nicht alle Podcasts getagt. Gehen Sie zu Ihren<a href="
-"\"%(subscriptions-url)s\">abonnements</a> und tagen sie einige."
+"Sie haben nicht alle Podcasts getagt. Gehen Sie zu Ihren<a "
+"href=\"%(subscriptions-url)s\">abonnements</a> und tagen sie einige."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2466,8 +2441,8 @@ msgstr "Dein Passwort wurde zurückgesetzt"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 
 #: mygpo/web/templates/password_reset_failed.html:4
@@ -2529,7 +2504,7 @@ msgstr "Abonnements"
 msgid "Make Public"
 msgstr "Als Öffentlich markieren"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 #, fuzzy
 msgid "Privacy Policy"
 msgstr "Einstellungen"
@@ -2580,6 +2555,17 @@ msgstr ""
 "Da die Beschaffung der Namen und anderer Informationen etwas Zeit in "
 "Anspruch nehmen kann. Bis dies erledigt ist wird der Podcast auf diese Wiese "
 "dargestellt."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Reactivate"
+msgid "Archived User"
+msgstr "Wiederherstellen"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2735,49 +2721,53 @@ msgstr "Diese Episode wurde gelöscht"
 msgid "Unknown Episode"
 msgstr "Namenlose Episode"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Home"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Hilfe"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "Benutzer-Abonnements"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Empfehlungen"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 #, fuzzy
 msgid "Toplists"
 msgstr "Topliste"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Geräte"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 #, fuzzy
 msgid "My Userpage"
 msgstr "Benutzername"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Privatsphäre "
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "Auf gpodder.net verlinken"
 
@@ -2791,30 +2781,48 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "eine andere Seite"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "Werbung starten"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "Wenn Sie Fragen haben oder Ihre Werbung auf %(sitename)s schalten "
+#~ "möchten, wenden Sie sich bitte an <a "
+#~ "href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a>. Die Bezahlung "
+#~ "erfolgt einfach per Paypal."
+
+#, fuzzy
+#~ msgid "Login failed."
+#~ msgstr "Anmelden"
 
 #, fuzzy
 #~ msgid "Last update:"
@@ -2969,8 +2977,8 @@ msgstr "eine andere Seite"
 #~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> with the <a "
 #~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
 #~ msgstr ""
-#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> mit <a href="
-#~ "\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
+#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> mit <a "
+#~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
 
 #~ msgid "Nokia Podcasting on Symbian devices"
 #~ msgstr "Nokia Podcasting auf Symbian geräte"
@@ -3004,8 +3012,8 @@ msgstr "eine andere Seite"
 
 #, fuzzy
 #~ msgid ""
-#~ "A list of your devices can be found on the <a href=\"%(devices-url)s"
-#~ "\">devices page</a>."
+#~ "A list of your devices can be found on the <a href=\"%(devices-"
+#~ "url)s\">devices page</a>."
 #~ msgstr ""
 #~ "Eine Übersicht über Ihre Geräte finden Sie in der <a href=\"/devices/"
 #~ "\">Geräte-Liste</a>."
@@ -3047,22 +3055,23 @@ msgstr "eine andere Seite"
 #~ "Geräten synchronisiert. "
 
 #~ msgid ""
-#~ "By default we include information about your subscriptions in our <a href="
-#~ "\"%(toplist-url)s\">toplist</a> and <a href=\"%(suggestions-url)s"
-#~ "\">podcast suggestions</a>. <strong>We will never associate your username "
-#~ "and/or email address with your subscriptions on public pages.</strong> "
-#~ "You can even opt-out from our anonymized statistics at the <a href="
-#~ "\"%(privacy-url)s\">privacy page</a>. If you mark some podcasts as "
+#~ "By default we include information about your subscriptions in our <a "
+#~ "href=\"%(toplist-url)s\">toplist</a> and <a href=\"%(suggestions-"
+#~ "url)s\">podcast suggestions</a>. <strong>We will never associate your "
+#~ "username and/or email address with your subscriptions on public pages.</"
+#~ "strong> You can even opt-out from our anonymized statistics at the <a "
+#~ "href=\"%(privacy-url)s\">privacy page</a>. If you mark some podcasts as "
 #~ "private, they will also not show up in your sharable subscription list."
 #~ msgstr ""
 #~ "Standardmäßig fügen wir Informationen über Ihre Abonnements in unsere <a "
-#~ "href=\"%(toplist-url)s\">Topliste</a> und <a href=\"%(suggestions-url)s"
-#~ "\">Podcast Anregungen</a>. <strong> Wir werden nie Ihren Benutzernamen "
-#~ "und/oder e-Mail-Adresse Ihres Abonnements auf öffentlichen Seiten "
-#~ "veröffentlichen.</strong> Sie können sogar opt-Out aus unserer "
-#~ "anonymisierten Statistiken auf der <a href=\"%(privacy-url)s"
-#~ "\">Datenschutzseite.</a>. Wenn Sie einige Podcasts als privat markieren, "
-#~ "werden sie in Ihrer freigebbar Abonnementliste auch nicht auftauchen. "
+#~ "href=\"%(toplist-url)s\">Topliste</a> und <a href=\"%(suggestions-"
+#~ "url)s\">Podcast Anregungen</a>. <strong> Wir werden nie Ihren "
+#~ "Benutzernamen und/oder e-Mail-Adresse Ihres Abonnements auf öffentlichen "
+#~ "Seiten veröffentlichen.</strong> Sie können sogar opt-Out aus unserer "
+#~ "anonymisierten Statistiken auf der <a href=\"%(privacy-"
+#~ "url)s\">Datenschutzseite.</a>. Wenn Sie einige Podcasts als privat "
+#~ "markieren, werden sie in Ihrer freigebbar Abonnementliste auch nicht "
+#~ "auftauchen. "
 
 #~ msgid "Sharing your Subscriptions"
 #~ msgstr "Zeige deine Podcast-Abos anderen"
@@ -3073,8 +3082,8 @@ msgstr "eine andere Seite"
 #~ "can either share your private URL with your friends or make it public and "
 #~ "share your subscriptions with the whole world."
 #~ msgstr ""
-#~ "Wenn Sie andere wissen lassen über Ihre Podcasts, um Ihre <a href="
-#~ "\"%(share-url)s\">Sharing Seite</a> gehen werden wollen . Sie können "
+#~ "Wenn Sie andere wissen lassen über Ihre Podcasts, um Ihre <a href=\"%"
+#~ "(share-url)s\">Sharing Seite</a> gehen werden wollen . Sie können "
 #~ "entweder Ihre eigenen URL mit deinen Freunden oder öffentlich machen und "
 #~ "teilen Sie Ihre Abonnements mit der ganzen Welt."
 
@@ -3096,11 +3105,11 @@ msgstr "eine andere Seite"
 #~ msgstr "Passwort für Ihren Account bei %s zurücksetzen"
 
 #~ msgid ""
-#~ "Here is your new password for your account %(username)s on %(site)s: "
-#~ "%(password)s"
+#~ "Here is your new password for your account %(username)s on %(site)s: %"
+#~ "(password)s"
 #~ msgstr ""
-#~ "Hier ist dein neues Passwort für deinen Account %(username)s bei "
-#~ "%(site)s: %(password)s"
+#~ "Hier ist dein neues Passwort für deinen Account %(username)s bei %"
+#~ "(site)s: %(password)s"
 
 #~ msgid "Invalid Username entered"
 #~ msgstr "Invalid Username eingegeben "
@@ -3166,9 +3175,6 @@ msgstr "eine andere Seite"
 #~ "Während der Bearbeitung der Anfrage ist ein Fehler aufgetreten. Eine E-"
 #~ "mail, die diesen Vorfall beschreibt wurde an die Entwickler gesendet."
 
-#~ msgid "Your settings have been saved."
-#~ msgstr "Ihre Einstellungen wurden gespeichert."
-
 #~ msgid "Contact information and password"
 #~ msgstr "Kontakt-Infos und Passwort"
 
@@ -3199,9 +3205,9 @@ msgstr "eine andere Seite"
 
 #, fuzzy
 #~ msgid ""
-#~ "You have subscribed to <a href=\"%(subscriptions-url)s\">"
-#~ "%(subscription_count)s podcasts</a> on <a href=\"%(devices-url)s\">"
-#~ "%(device_count)s devices</a>. Now you can\n"
+#~ "You have subscribed to <a href=\"%(subscriptions-url)s\">%"
+#~ "(subscription_count)s podcasts</a> on <a href=\"%(devices-url)s\">%"
+#~ "(device_count)s devices</a>. Now you can\n"
 #~ "   <ul>\n"
 #~ "    <li><a href=\"%(share-url)s\">share your subscriptions with others</"
 #~ "a></li>\n"
@@ -3311,8 +3317,8 @@ msgstr "eine andere Seite"
 
 #, fuzzy
 #~ msgid ""
-#~ "or show <a href=\"%(episode-toplist-url)s?lang=&types=%(type_param)s"
-#~ "\">all languages</a>."
+#~ "or show <a href=\"%(episode-toplist-url)s?lang=&types=%"
+#~ "(type_param)s\">all languages</a>."
 #~ msgstr "oder <a href=\"/toplist?lang=\">alle Sprachen</a> anzeigen."
 
 #~ msgid "You think that's not much?"
@@ -3330,8 +3336,8 @@ msgstr "eine andere Seite"
 #, fuzzy
 #~ msgid ""
 #~ "You can access a feed containing your favorites episodes at\n"
-#~ "     <strong><a href=\"%(favorites-feed-url)s\">http://%(domain)s"
-#~ "%(favorites-feed-url)s</a></strong>."
+#~ "     <strong><a href=\"%(favorites-feed-url)s\">http://%(domain)s%"
+#~ "(favorites-feed-url)s</a></strong>."
 #~ msgstr ""
 #~ "\n"
 #~ "     Den Feed mit deinen Lieblings-Episoden findest du unter <strong><a "
@@ -3382,10 +3388,10 @@ msgstr "eine andere Seite"
 
 #, fuzzy
 #~ msgid ""
-#~ "Find new interesting podcasts in our <a href=\"%(directory-home-url)s"
-#~ "\">directory</a> and <a href=\"%(toplist-url)s\">toplist</a>, see what's "
-#~ "<a href=\"%(episode-toplist-url)s\">currently listened</a> to by our "
-#~ "users and get personalized suggestions."
+#~ "Find new interesting podcasts in our <a href=\"%(directory-home-"
+#~ "url)s\">directory</a> and <a href=\"%(toplist-url)s\">toplist</a>, see "
+#~ "what's <a href=\"%(episode-toplist-url)s\">currently listened</a> to by "
+#~ "our users and get personalized suggestions."
 #~ msgstr ""
 #~ "Entdecken Sie interessante neue Podcasts in unserem <a href=\"/directory/"
 #~ "\">Verzeichnis</a> oder der <a href=\"/toplist/\">Toplliste</a> und sehen "
@@ -3560,8 +3566,8 @@ msgstr "eine andere Seite"
 
 #~ msgid ""
 #~ "These are the %(count)s most listened episodes of the last seven days of "
-#~ "all languages. You can chose to show only selected languages <a href="
-#~ "\"#languages\">below</a>."
+#~ "all languages. You can chose to show only selected languages <a "
+#~ "href=\"#languages\">below</a>."
 #~ msgstr ""
 #~ "Das sind die %(count)s meist-gehörten Episoden der letzten 7 Tage in "
 #~ "allen Sprachen. Wenn nur bestimmte Sprachen angezeigt werden sollen, "
@@ -3569,13 +3575,13 @@ msgstr "eine andere Seite"
 
 #~ msgid ""
 #~ "The are the %(count)s most listened episodes of the last seven days for "
-#~ "the languages %(lang)s. You can select the included languages <a href="
-#~ "\"#languages\">below</a>."
+#~ "the languages %(lang)s. You can select the included languages <a "
+#~ "href=\"#languages\">below</a>."
 #~ msgstr ""
 #~ "Das sind die %(count)s am häufig\n"
 #~ "The are the %(count)s most listened episodes of the last seven days for "
-#~ "the languages %(lang)s. You can select the included languages <a href="
-#~ "\"#languages\">below</a>."
+#~ "the languages %(lang)s. You can select the included languages <a "
+#~ "href=\"#languages\">below</a>."
 
 #~ msgid "or show <a href=\"/toplist/episodes?lang=\">all languages</a>."
 #~ msgstr ""
@@ -3593,13 +3599,13 @@ msgstr "eine andere Seite"
 #~ "href=\"/publisher/advertise\">mehr...</a>"
 
 #~ msgid ""
-#~ "These are the %(count)s most subscribed podcasts for the languages "
-#~ "%(lang)s. You can select the included languages <a href=\"#languages"
-#~ "\">below</a>."
+#~ "These are the %(count)s most subscribed podcasts for the languages %"
+#~ "(lang)s. You can select the included languages <a "
+#~ "href=\"#languages\">below</a>."
 #~ msgstr ""
-#~ "Das sind die %(count)s am häufig abonnierten Podcasts in den Sprachen "
-#~ "%(lang)s. Sie können die angezeigten Sprachen <a href=\"#languages"
-#~ "\">auswählen</a>."
+#~ "Das sind die %(count)s am häufig abonnierten Podcasts in den Sprachen %"
+#~ "(lang)s. Sie können die angezeigten Sprachen <a "
+#~ "href=\"#languages\">auswählen</a>."
 
 #~ msgid "Search:"
 #~ msgstr "Suchen"

--- a/mygpo/locale/en/LC_MESSAGES/django.po
+++ b/mygpo/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr ""
 
@@ -187,7 +187,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr ""
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -275,25 +279,35 @@ msgstr ""
 msgid "User-Agent"
 msgstr ""
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr ""
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr ""
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -375,8 +389,8 @@ msgstr ""
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
 
 #: mygpo/directory/templates/directory.html:46
@@ -436,8 +450,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr ""
 
@@ -460,14 +474,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr ""
 
@@ -514,7 +528,7 @@ msgid "OK"
 msgstr ""
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr ""
 
@@ -545,7 +559,7 @@ msgstr ""
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr ""
 
@@ -561,6 +575,7 @@ msgstr ""
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr ""
 
@@ -579,8 +594,8 @@ msgstr ""
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr ""
 
@@ -612,20 +627,20 @@ msgstr ""
 msgid "Client Access"
 msgstr ""
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -646,7 +661,7 @@ msgid "Action"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr ""
 
@@ -656,7 +671,7 @@ msgstr ""
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr ""
@@ -690,7 +705,7 @@ msgstr ""
 msgid "Earlier"
 msgstr ""
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -768,16 +783,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -817,24 +832,24 @@ msgstr ""
 msgid "Episode History"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr ""
@@ -897,9 +912,9 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr ""
 
@@ -956,18 +971,6 @@ msgid ""
 "advertisement period."
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr ""
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr ""
@@ -988,7 +991,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1007,7 +1010,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr ""
 
@@ -1089,8 +1092,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/info.html:27
@@ -1170,8 +1173,8 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1226,8 +1229,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1246,21 +1249,21 @@ msgstr ""
 msgid "Show Group Stats"
 msgstr ""
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1329,8 +1332,8 @@ msgstr ""
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr ""
 
@@ -1345,7 +1348,7 @@ msgid "User Page"
 msgstr ""
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr ""
 
@@ -1458,9 +1461,9 @@ msgstr ""
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1469,22 +1472,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr ""
@@ -1502,27 +1505,27 @@ msgstr ""
 msgid "No Suggestions Yet"
 msgstr ""
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr ""
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr ""
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr ""
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr ""
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr ""
 
@@ -1557,9 +1560,9 @@ msgid "You are already registered."
 msgstr ""
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr ""
 
@@ -1635,125 +1638,115 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr ""
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr ""
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+msgid "Your data has been archived."
+msgstr ""
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr ""
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr ""
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr ""
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr ""
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr ""
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr ""
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr ""
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr ""
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr ""
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr ""
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr ""
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr ""
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr ""
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr ""
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr ""
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr ""
 
@@ -1795,110 +1788,97 @@ msgstr ""
 msgid "Disconnect"
 msgstr ""
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr ""
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr ""
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr ""
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr ""
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr ""
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr ""
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr ""
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -1922,15 +1902,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -1958,7 +1936,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr ""
 
@@ -1974,18 +1952,17 @@ msgstr ""
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2074,7 +2051,7 @@ msgid "Thanks"
 msgstr ""
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2193,9 +2170,9 @@ msgstr ""
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2211,7 +2188,7 @@ msgid "Delete Permanently"
 msgstr ""
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr ""
 
@@ -2235,15 +2212,15 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
 
 #: mygpo/web/templates/password_reset.html:4
@@ -2257,8 +2234,8 @@ msgstr ""
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 
 #: mygpo/web/templates/password_reset_failed.html:4
@@ -2314,7 +2291,7 @@ msgstr ""
 msgid "Make Public"
 msgstr ""
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr ""
 
@@ -2346,6 +2323,15 @@ msgid ""
 "Because we display names after we have fetched the information from the feed "
 "-- and this may take some time. Until this is completed, the podcast will "
 "simply be called this way."
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+msgid "Archived User"
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
 msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
@@ -2493,47 +2479,51 @@ msgstr ""
 msgid "Unknown Episode"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr ""
 
@@ -2547,27 +2537,27 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr ""

--- a/mygpo/locale/es/LC_MESSAGES/django.po
+++ b/mygpo/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: my.gpodder.org\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2010-02-08 18:45-0300\n"
 "Last-Translator: Silvio Sisto <silvio.sisto@gmail.com>\n"
 "Language-Team: gpodder team <gpodder-devel@lists.berlios.de>\n"
@@ -25,7 +25,7 @@ msgstr ""
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr ""
 
@@ -188,7 +188,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr ""
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -277,26 +281,36 @@ msgstr ""
 msgid "User-Agent"
 msgstr ""
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr ""
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 #, fuzzy
 msgid "No user found"
 msgstr "No se encuentra"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -378,8 +392,8 @@ msgstr ""
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
 
 #: mygpo/directory/templates/directory.html:46
@@ -443,8 +457,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr ""
 
@@ -468,14 +482,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 #, fuzzy
 msgid "Podcasts"
 msgstr "Mejores podcasts"
@@ -524,7 +538,7 @@ msgid "OK"
 msgstr ""
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 #, fuzzy
 msgid "Missing Podcast"
 msgstr "Mejores podcasts"
@@ -558,7 +572,7 @@ msgstr "Mejores podcasts"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 #, fuzzy
 msgid "Podcast Lists"
 msgstr "Mejores podcasts"
@@ -575,6 +589,7 @@ msgstr ""
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr ""
 
@@ -593,8 +608,8 @@ msgstr ""
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Buscar"
 
@@ -628,20 +643,20 @@ msgstr "Mejores podcasts"
 msgid "Client Access"
 msgstr ""
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Historial"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 #, fuzzy
@@ -663,7 +678,7 @@ msgid "Action"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr ""
 
@@ -673,7 +688,7 @@ msgstr ""
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr ""
@@ -707,7 +722,7 @@ msgstr ""
 msgid "Earlier"
 msgstr ""
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -788,16 +803,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -839,24 +854,24 @@ msgstr ""
 msgid "Episode History"
 msgstr "Mejores podcasts"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr ""
@@ -920,9 +935,9 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr ""
 
@@ -981,18 +996,6 @@ msgid ""
 "advertisement period."
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr ""
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr ""
@@ -1015,7 +1018,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1035,7 +1038,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr ""
 
@@ -1119,8 +1122,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/info.html:27
@@ -1202,8 +1205,8 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1258,8 +1261,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1278,22 +1281,22 @@ msgstr ""
 msgid "Show Group Stats"
 msgstr ""
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 #, fuzzy
 msgid "Data updated"
 msgstr "Dispositivos"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1363,8 +1366,8 @@ msgstr ""
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr ""
 
@@ -1379,7 +1382,7 @@ msgid "User Page"
 msgstr ""
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Configuración"
 
@@ -1494,9 +1497,9 @@ msgstr ""
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1505,22 +1508,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr ""
@@ -1539,27 +1542,27 @@ msgstr ""
 msgid "No Suggestions Yet"
 msgstr "Sugerencias"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Computadora de escritorio"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Laptop"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr ""
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Servidor"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Otro"
 
@@ -1596,9 +1599,9 @@ msgid "You are already registered."
 msgstr ""
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr ""
 
@@ -1676,130 +1679,121 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 #, fuzzy
 msgid "Your user has been activated. You can log in now."
 msgstr "El capítulo ha sido eliminado"
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr ""
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+msgid "Your data has been archived."
+msgstr "El capítulo ha sido eliminado"
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr ""
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 #, fuzzy
 msgid "Your account has been disconnected"
 msgstr "El capítulo ha sido eliminado"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr ""
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr ""
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 #, fuzzy
 msgid "E-Mail address"
 msgstr "Su dirección de E-Mail"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr ""
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr ""
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr ""
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr ""
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr ""
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 #, fuzzy
 msgid "Device ID"
 msgstr "Dispositivos"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 #, fuzzy
 msgid "ID on device"
 msgstr "Dispositivos"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr ""
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr ""
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr ""
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr ""
 
@@ -1843,113 +1837,100 @@ msgstr ""
 msgid "Disconnect"
 msgstr "Descubrir"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 #, fuzzy
 msgid "Account"
 msgstr "Configuración de cuenta"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr ""
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Descubrir"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 #, fuzzy
 msgid "Directory"
 msgstr "Historial"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 #, fuzzy
 msgid "Questions"
 msgstr "Sugerencias"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr ""
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr ""
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -1973,15 +1954,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2009,7 +1988,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr ""
 
@@ -2025,18 +2004,17 @@ msgstr ""
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2129,7 +2107,7 @@ msgid "Thanks"
 msgstr ""
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2252,9 +2230,9 @@ msgstr ""
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2271,7 +2249,7 @@ msgid "Delete Permanently"
 msgstr ""
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr ""
 
@@ -2295,15 +2273,15 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
 
 #: mygpo/web/templates/password_reset.html:4
@@ -2318,8 +2296,8 @@ msgstr "El capítulo ha sido eliminado"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 
 #: mygpo/web/templates/password_reset_failed.html:4
@@ -2376,7 +2354,7 @@ msgstr ""
 msgid "Make Public"
 msgstr ""
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 #, fuzzy
 msgid "Privacy Policy"
 msgstr "Configuración"
@@ -2410,6 +2388,15 @@ msgid ""
 "Because we display names after we have fetched the information from the feed "
 "-- and this may take some time. Until this is completed, the podcast will "
 "simply be called this way."
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+msgid "Archived User"
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
 msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
@@ -2558,48 +2545,52 @@ msgstr "El capítulo ha sido eliminado"
 msgid "Unknown Episode"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Sugerencias"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 #, fuzzy
 msgid "Toplists"
 msgstr "Mejores podcasts"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Dispositivos"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr ""
 
@@ -2613,28 +2604,28 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr ""
 

--- a/mygpo/locale/fr/LC_MESSAGES/django.po
+++ b/mygpo/locale/fr/LC_MESSAGES/django.po
@@ -9,10 +9,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
-"PO-Revision-Date: 2018-06-20 06:29+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
+"PO-Revision-Date: 2026-08-30 19:54+0200\n"
 "Last-Translator: Irriep Nala Novram <allannkorh@yahoo.fr>, 2019\n"
 "Language-Team: French (https://www.transifex.com/yaron/teams/87581/fr/)\n"
 "Language: fr\n"
@@ -20,6 +20,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.9\n"
 
 #: mygpo/administration/templates/admin/activate-user.html:9
 #: mygpo/administration/templates/admin/activate-user.html:12
@@ -30,7 +31,7 @@ msgstr "Activer l'utilisateur"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
@@ -156,7 +157,7 @@ msgstr "Tâches de Celery programmées"
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr "Autorisations de l'éditeur"
 
@@ -193,7 +194,11 @@ msgstr "Si vous avez des questions, veuillez visiter %(url)s"
 msgid "Merge Podcasts and Episodes"
 msgstr "Fusionner des podcasts et des épisodes"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -220,8 +225,6 @@ msgid "General Stats"
 msgstr "Statistiques Général"
 
 #: mygpo/administration/templates/admin/overview.html:23
-#, fuzzy
-#| msgid "Resend activation e-mail"
 msgid "Resend Activation Email"
 msgstr "Renvoyer le courriel d'activation"
 
@@ -230,8 +233,6 @@ msgid "Assign Publisher Permissions"
 msgstr "Attribuer des autorisations de publication"
 
 #: mygpo/administration/templates/admin/resend-acivation.html:12
-#, fuzzy
-#| msgid "Resend activation e-mail"
 msgid "Resend Activation email"
 msgstr "Renvoyer le courriel d'activation"
 
@@ -288,27 +289,36 @@ msgstr "Rafraîchir"
 msgid "User-Agent"
 msgstr "Utilisateur-Agent"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "Pas de podcast avec URL {url}"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr "Indiquez un nom d'utilisateur ou une adresse électronique."
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr "Aucun utilisateur trouvé"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr "Utilisateur {username} ({email}) activé"
 
-#: mygpo/administration/views.py:375
-#, fuzzy, python-brace-format
-#| msgid "User {username} ({email}) activated"
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr "L'utilisateur {username} a déjà été activé"
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr "L'utilisateur {username} a été archivé."
+
+#: mygpo/administration/views.py:389
+#, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr "Utilisateur {username} ({email}) activé"
 
@@ -389,11 +399,11 @@ msgstr "Répertoire de podcasts"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"%(listtitle)s <span class=\"by-user\">par <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">par <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -452,8 +462,8 @@ msgstr "Voir la licence"
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podcast"
 
@@ -476,14 +486,14 @@ msgid "Podcasts with License Information"
 msgstr "Podcasts avec informations de licence"
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr "Licence"
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr "Podcasts"
 
@@ -530,7 +540,7 @@ msgid "OK"
 msgstr "D'accord"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr "Podcast manquant"
 
@@ -562,7 +572,7 @@ msgstr "Podcast de parrainage"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr "Listes de podcasts"
 
@@ -578,6 +588,7 @@ msgstr "Utilisateur"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "Télécharger"
 
@@ -596,8 +607,8 @@ msgstr "Créez une liste de podcasts sur un sujet que vous aimez"
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Chercher"
 
@@ -630,20 +641,20 @@ msgstr "Topliste"
 msgid "Client Access"
 msgstr "Accès client"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr "%d podcasts ajoutés"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Histoire"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -664,7 +675,7 @@ msgid "Action"
 msgstr "Action"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Appareil"
 
@@ -674,7 +685,7 @@ msgstr "Ajouter"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr "Historique d'abonnement"
@@ -708,7 +719,7 @@ msgstr "Maintenant"
 msgid "Earlier"
 msgstr "Plus tôt"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr "pas encore d'histoire"
 
@@ -789,16 +800,16 @@ msgstr "Listes de podcasts par %(username)s"
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s n'a pas encore créé de liste de podcast."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr "Vous devez spécifier un titre."
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr "\"{title}\" n'est pas un titre valide"
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr "Merci d'avoir noté !"
 
@@ -813,7 +824,7 @@ msgstr "Podcast inconnu"
 #: mygpo/podcasts/models.py:700
 #, python-brace-format
 msgid "Unknown Podcast from {domain}"
-msgstr "Podcast inconnu de {domaine}"
+msgstr "Podcast inconnu de {domain}"
 
 #: mygpo/podcasts/templates/episode.html:85
 #: mygpo/podcasts/templates/episodes.html:27
@@ -838,24 +849,24 @@ msgstr "Préféré"
 msgid "Episode History"
 msgstr "Histoire de l'épisode"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Podcast sans nom"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr "par"
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr "Flux"
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr "abonnés"
@@ -880,7 +891,7 @@ msgstr "Abonnez-vous sur tous les appareils"
 
 #: mygpo/podcasts/templates/podcast.html:110
 msgid "Unsubscribe from all devices "
-msgstr "Se désabonner de tous les appareils"
+msgstr "Se désabonner sur tous les appareils"
 
 #: mygpo/podcasts/templates/podcast.html:149
 #: mygpo/podcasts/templates/podcast.html:164
@@ -921,9 +932,9 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "Annoncer"
 
@@ -995,22 +1006,6 @@ msgstr ""
 "intéressants. Cependant, nous ne garantissons pas un certain nombre de "
 "visiteurs pendant votre période d'annonce."
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "Démarrer votre annonce"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"Veuillez contacter <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</"
-"a> si vous souhaitez faire de la publicité sur %(sitename)s ou si vous avez "
-"des questions. Les paiements sont effectués via PayPal à l'adresse thp@perli."
-"net."
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "Épisode sans nom"
@@ -1034,7 +1029,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr "Enregistrer"
@@ -1053,7 +1048,7 @@ msgstr "Retour à la page Podcast"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Épisodes"
 
@@ -1142,11 +1137,11 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
-"Vous pouvez trouver des détails supplémentaires sur la <a href="
-"\"%(advertise-url)s\">page de publicité</a>."
+"Vous pouvez trouver des détails supplémentaires sur la <a "
+"href=\"%(advertise-url)s\">page de publicité</a>."
 
 #: mygpo/publisher/templates/publisher/info.html:27
 #, python-format
@@ -1158,19 +1153,7 @@ msgstr ""
 "trouver des informations précieuses sur les podcasts que vous avez publiés."
 
 #: mygpo/publisher/templates/publisher/info.html:30
-#, fuzzy, python-format
-#| msgid ""
-#| "The Publisher Pages are currently in Beta, but if you are publishing a "
-#| "podcast listed on %(sitename)s, feel free to apply by sending a mail "
-#| "with\n"
-#| "  <ul>\n"
-#| "   <li>your username on %(sitename)s (<a href=\"%(register-url)s"
-#| "\">register if you don't have one</a>)</li>\n"
-#| "   <li>the name and URL of the podcast you are publishing</li>\n"
-#| "   <li>an email address that is visible somewhere on the podcast's "
-#| "website (to legitimate you)\n"
-#| "  </ul>\n"
-#| "  to <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a>."
+#, python-format
 msgid ""
 "The Publisher Pages are currently in Beta, but if you are publishing a "
 "podcast listed on %(sitename)s, feel free to apply by sending a mail with\n"
@@ -1187,8 +1170,8 @@ msgstr ""
 "publiez un podcast répertorié sur %(sitename)s, , n'hésitez pas à postuler "
 "en envoyant un courriel à\n"
 "<ul>\n"
-"<li>votre nom d'utilisateur sur %(sitename)s (<a href=\"%(register-url)s"
-"\">inscrivez-vous si vous n'en avez pas</a>)</li>\n"
+"<li>votre nom d'utilisateur arobase %(sitename)s (<a "
+"href=\"%(register-url)s\">inscrivez-vous si vous n'en avez pas</a>)</li>\n"
 "<li>le nom et l'URL du podcast que vous publiez</li>\n"
 "<li>une adresse e-mail visible quelque part sur le site Web du podcast (pour "
 "vous légitimer)\n"
@@ -1201,8 +1184,8 @@ msgid ""
 "If you already are registered as a publisher, please <a href=\"%(login-url)s?"
 "next=/publisher/\">login</a>."
 msgstr ""
-"Si vous êtes déjà inscrit en tant qu'éditeur, veuillez <a href="
-"\"%(login-url)s?next=/publisher/\">vous connecter</a>."
+"Si vous êtes déjà inscrit en tant qu'éditeur, veuillez <a "
+"href=\"%(login-url)s?next=/publisher/\">vous connecter</a>."
 
 #: mygpo/publisher/templates/publisher/info.html:41
 #, python-format
@@ -1240,10 +1223,8 @@ msgstr ""
 "Les informations de podcast sont régulièrement extraites du flux de podcast"
 
 #: mygpo/publisher/templates/publisher/podcast.html:60
-#, fuzzy
-#| msgid "Update now"
 msgid "Updates"
-msgstr "Mettre à jour maintenant"
+msgstr "Mises à jour"
 
 #: mygpo/publisher/templates/publisher/podcast.html:62
 msgid "Update interval:"
@@ -1261,8 +1242,8 @@ msgstr ""
 msgid "Update now"
 msgstr "Mettre à jour maintenant"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -1281,9 +1262,10 @@ msgid ""
 "p/pubsubhubbub/\">PubSubHubbu</a> hub, %(sitename)s can immediatelly update "
 "your podcast when a new episode is released."
 msgstr ""
-"Si vous publiez votre flux de podcast via un <a href=\"https://code.google."
-"com/p/pubsubhubbub/\">PubSubHubbu</a> hub, %(sitename)s pourra immédiatement "
-"mettre à jour votre podcast lorsqu'un nouvel épisode est publié."
+"Si vous publiez votre flux de podcast via un <a href=\"https://"
+"code.google.com/p/pubsubhubbub/\">PubSubHubbu</a> hub, %(sitename)s pourra "
+"immédiatement mettre à jour votre podcast lorsqu'un nouvel épisode est "
+"publié."
 
 #: mygpo/publisher/templates/publisher/podcast.html:157
 #, python-format
@@ -1330,11 +1312,11 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
-"Nous avons trouvé la licence suivante dans votre podcast : <a href="
-"\"%(license)s\">%(license)s</a>"
+"Nous avons trouvé la licence suivante dans votre podcast : <a "
+"href=\"%(license)s\">%(license)s</a>"
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
 msgid ""
@@ -1357,7 +1339,7 @@ msgstr "Lien"
 msgid "Show Group Stats"
 msgstr "Afficher les statistiques du groupe"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
@@ -1365,15 +1347,15 @@ msgstr ""
 "La mise à jour a été planifiée. Cela peut prendre un certain temps avant que "
 "les résultats ne soient visibles."
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr "Données mises à jour"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr "Jeton d'éditeur mis à jour"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr "Partie supprimée {slug} de {episode}"
@@ -1446,8 +1428,8 @@ msgstr "Partager"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Abonnements"
 
@@ -1462,7 +1444,7 @@ msgid "User Page"
 msgstr "Page utilisateur"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Paramètres"
 
@@ -1582,13 +1564,13 @@ msgstr "%(episode_count)s épisodes"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
-"Vous n'avez pas encore d'abonnement. Configurez votre <a href=\"%(devices)s"
-"\">clients de podcast</a> et <a href=\"%(directory)s\">découvrez des "
-"podcasts intéressants</a>."
+"Vous n'avez pas encore d'abonnement. Configurez votre <a "
+"href=\"%(devices)s\">clients de podcast</a> et <a "
+"href=\"%(directory)s\">découvrez des podcasts intéressants</a>."
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
 #: mygpo/suggestions/templates/suggestions.html:54
@@ -1596,23 +1578,23 @@ msgstr ""
 msgid "Download OPML"
 msgstr "Télécharger OPML"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "Abonnements podcast de %(username)s sur %(site)s"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 "Changements récents dans les abonnements podcast de %(username)s sur %(site)s"
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "%(username)s s'est abonné à %(podcast)s (%(site)s)"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "%(username)s s'est désabonné de %(podcast)s (%(site)s)"
@@ -1630,27 +1612,27 @@ msgstr "Pas d'intérêt"
 msgid "No Suggestions Yet"
 msgstr "Aucune suggestion pour le moment"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Bureau"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Ordinateur portable"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Téléphone portable"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Serveur"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr "Tablette"
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Autre"
 
@@ -1687,9 +1669,9 @@ msgid "You are already registered."
 msgstr "Vous êtes déjà inscrit."
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "S'inscrire"
 
@@ -1711,8 +1693,8 @@ msgid ""
 "If it doesn't arrive, you can <a href=\"%(resend-activation-url)s\">resend</"
 "a> it."
 msgstr ""
-"S'il n'arrive pas, vous pouvez demander qu'il soit <a href="
-"\"%(resend-activation-url)s\">réenvoyé</a>."
+"S'il n'arrive pas, vous pouvez demander qu'il soit <a "
+"href=\"%(resend-activation-url)s\">réenvoyé</a>."
 
 #: mygpo/users/templates/registration/resend_activation.html:4
 #: mygpo/users/templates/registration/resend_activation.html:8
@@ -1740,10 +1722,8 @@ msgid "Sent Activation Email"
 msgstr "Courriel d'activation envoyé"
 
 #: mygpo/users/templates/registration/resent_activation.html:11
-#, fuzzy
-#| msgid "The activation email has been reset."
 msgid "The activation email has been resent."
-msgstr "Le courriel d'activation a été réinitialisé."
+msgstr "Le courriel d'activation a été ré-envoyé."
 
 #: mygpo/users/views/device.py:82 mygpo/users/views/device.py:174
 msgid "Synchronize with the following devices"
@@ -1776,53 +1756,63 @@ msgstr "Impossible de télécharger des abonnements: {err}"
 msgid "Your subscription will be updated in a moment."
 msgstr "Votre abonnement sera mis à jour dans un instant."
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr "Nom d'utilisateur ou adresse courriel déjà utilisé"
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr "Le lien d'activation n'est pas valide ou a déjà expiré."
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr "Votre utilisateur a été activé. Vous pouvez vous connecter maintenant."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr "Un nom d'utilisateur ou une adresse courriel sont requis."
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "L'utilisateur n'existe pas."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+msgid "Your data has been archived."
+msgstr "Votre compte a été archivé."
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "Votre compte a déjà été activé. Allez-y et connectez-vous."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 "Zut alors ! Quelque chose s'est mal passé. Veuillez vérifier les données que "
 "vous avez entrées."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr "Votre compte a été déconnecté"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr "Nom d'utilisateur manquant"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr "Mot de passe manquant"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Nom d'utilisateur ou mot de passe incorrect."
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
@@ -1830,79 +1820,55 @@ msgstr ""
 "Veuillez d'abord activer votre compte. Nous venons de renvoyer votre "
 "courriel d'activation"
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr "Échec de la connexion."
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr "La connexion avec Google n'est actuellement pas possible."
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-"Votre compte a été connecté avec {google}. Ouvrez les paramètres pour "
-"changer cela."
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-"Aucun compte connecté avec votre compte Google %s. Veuillez vous identifier "
-"pour vous connecter."
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "Adresse courriel"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Mot de passe actuel"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Nouveau mot de passe"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "Confirmez le mot de passe"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr "Écrivez quelques mots sur vous"
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Nom"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Type"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "ID de l'appareil"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr "ID sur l'appareil"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "Partager cet abonnement avec d'autres utilisateurs (publique)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Aucun appareil sélectionné"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Veuillez entrer votre nom d'utilisateur"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "ou l'adresse courriel utilisée lors de l'inscription"
 
@@ -1945,110 +1911,97 @@ msgstr "Connecté avec %(gmail)s"
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr "Connecter"
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "Compte"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "S'identifier"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr "Connectez-vous avec Google"
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Découvrez"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "Répertoire"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr "Soutien"
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr "Docs"
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr "&nbsp;Liste de diffusion"
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr "Des questions"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr "Nous&nbsp;Soutenir"
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr "Faire un don"
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr "Suivre"
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr "Blog"
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr "Blog&nbsp;(RSS)"
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr "Développer"
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr "API"
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "Bibliothèques"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr "Clients"
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr "Publier"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr "Avoir &nbsp;accès"
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr "Lien&nbsp;vers&nbsp;nous"
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr "hébergement fourni par tornadovps.com"
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr "Contribuer"
 
@@ -2076,22 +2029,17 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 "Si vous voulez contribuer à gpodder.net en écrivant du code, jetez un œil à "
 "la page de <a href=\"/developer/\">Dévelopment</a>. Nous apprécions "
 "également les contributions de travaux autres que de codage, tels que la "
-"conception Web et d'interface, les opérations de serveur, les tests, etc. Si "
-"cela vous intéresse, rejoignez la <a href=\"https://gpodder.github.io/docs/"
-"mailing-list.html\">liste de diffusion</a> ou le canal IRC #gpodder sur chat."
-"freenode.net."
+"conception Web et d'interface, les opérations de serveur, les tests, etc.."
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2123,7 +2071,7 @@ msgstr "Oui"
 msgid "No"
 msgstr "Non"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "Aperçu"
 
@@ -2139,9 +2087,9 @@ msgstr "Nouveaux épisodes"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 "Bienvenue à %(site)s ! Si ceci est votre première visite, vous devez "
 "configurer votre <a href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
@@ -2152,14 +2100,12 @@ msgstr ""
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 "Si vous avez des problèmes, regardez la <a href=\"%(help)s\">documentation</"
-"a> ou poser des questions sur la <a href=\"https://gpodder.github.io/docs/"
-"mailing-list.html\">liste de diffusion</a> ou encore sur le <a href="
-"\"https://github.com/gpodder/mygpo/issues\">forum</a>."
+"a> ou posez des questions sur le <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">forum</a>."
 
 #: mygpo/web/templates/dashboard.html:81
 #, python-format
@@ -2249,7 +2195,7 @@ msgid "Thanks"
 msgstr "Merci"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr "Développement"
 
@@ -2258,12 +2204,6 @@ msgid "Webservice"
 msgstr "Service Web"
 
 #: mygpo/web/templates/developer.html:18
-#, fuzzy
-#| msgid ""
-#| "The sourcecode of the webservice gpodder.net is released as open source "
-#| "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted "
-#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://bugs.gpodder."
-#| "org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
 msgid ""
 "The sourcecode of the webservice gpodder.net is released as open source "
 "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted at "
@@ -2272,8 +2212,8 @@ msgid ""
 msgstr ""
 "Le code source du webservice gpodder.net est publié en open source sous "
 "AGPLv3 et <a href=\"https://github.com/gpodder/mygpo\">hébergé chez GitHub</"
-"a>. Les bugs peuvent être signalés à <a href=\"https://bugs.gpodder.org/"
-"enter_bug.cgi?product=gpodder.net\">gPodder bugtracker</a>."
+"a>. Les bugs peuvent être signalés via <a href=\"https://github.com/gpodder/"
+"gpodder/issues\">les tickets GitHub</a>."
 
 #: mygpo/web/templates/developer.html:21
 msgid "Integrating Clients"
@@ -2286,8 +2226,9 @@ msgid ""
 "en/latest/dev/libraries.html\">client libraries</a>."
 msgstr ""
 "Si vous souhaitez intégrer gpodder.net à un client de podcasting, vous "
-"pouvez utiliser l’un des logiciels existants de <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/dev/libraries.html\">bibliothèques clientes</a>."
+"pouvez utiliser l’un des logiciels existants de <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/dev/libraries.html\">bibliothèques "
+"clientes</a>."
 
 #: mygpo/web/templates/developer.html:23
 msgid ""
@@ -2388,9 +2329,9 @@ msgstr "Non synchronisé"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 "Vous n'avez encore aucun appareil. Aller à la page <a href=\"https://"
 "gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> pour "
@@ -2409,7 +2350,7 @@ msgid "Delete Permanently"
 msgstr "Supprimer définitivement"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "Épisodes préférés"
 
@@ -2435,18 +2376,18 @@ msgstr ""
 "ligne dans quelques minutes. Attendez un peu et réessayez!"
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "Mes balises"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"Vous n'avez pas encore tagué de podcasts. Aller à vos <a href="
-"\"%(subscriptions-url)s\">abonnements</a> et balisez en quelques un."
+"Vous n'avez pas encore tagué de podcasts. Aller à vos <a "
+"href=\"%(subscriptions-url)s\">abonnements</a> et balisez en quelques un."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2459,8 +2400,8 @@ msgstr "Votre mot de passe a été réinitialisé"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 "Vous auriez dû recevoir un courrie avec votre nouveau mot de passe. Veuillez "
 "vous <a href=\"%(login-url)s\">connecter</a> maintenant."
@@ -2525,7 +2466,7 @@ msgstr "Abonnements privés"
 msgid "Make Public"
 msgstr "Rendre publique"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
@@ -2539,16 +2480,12 @@ msgid "Subscribe to %(podcasttitle)s"
 msgstr "S'abonner à %(podcasttitle)s"
 
 #: mygpo/web/templates/subscribe.html:41
-#, fuzzy
-#| msgid ""
-#| "You can't subscribe to this podcast, because you don't have any devices "
-#| "(on which you don't have subscribed to the podcast already."
 msgid ""
 "You can't subscribe to this podcast, because you don't have any devices (on "
 "which you don't have subscribed to the podcast already)."
 msgstr ""
-"Vous ne pouvez pas vous abonner à ce podcast, car vous ne possédez aucun "
-"appareil (sur lequel vous ne vous êtes pas encore abonné."
+"Vous ne pouvez pas vous abonner à ce podcast, car tous vos appareils sont "
+"déjà abonnés à ce podcast."
 
 #: mygpo/web/templates/subscribe.html:43
 msgid "Create Device"
@@ -2559,11 +2496,6 @@ msgid "Why Unnamed Podcast?"
 msgstr "Pourquoi un podcast sans nom ?"
 
 #: mygpo/web/templates/subscribe.html:49
-#, fuzzy
-#| msgid ""
-#| "Because we display names after we have fetched the information form the "
-#| "feed -- and this may take some time. Until this is completed, the podcast "
-#| "will simply be called this way."
 msgid ""
 "Because we display names after we have fetched the information from the feed "
 "-- and this may take some time. Until this is completed, the podcast will "
@@ -2572,6 +2504,15 @@ msgstr ""
 "Parce que nous affichons les noms après avoir récupéré les informations du "
 "flux - cela peut prendre un certain temps. Jusqu'à ce que cela soit terminé, "
 "le podcast sera simplement appelé de cette façon."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+msgid "Archived User"
+msgstr "Utilisateur archivé"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2726,47 +2667,51 @@ msgstr "Cet épisode a été supprimé"
 msgid "Unknown Episode"
 msgstr "Épisode inconnu"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Accueil"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Aide"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "Abonnements de l'utilisateur"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Suggestions"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr "Fonctionnalités"
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr "Toplistes"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Appareils"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr "Communauté"
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr "Ma page d'utilisateur"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Vie privée"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "Lien vers gpodder.net"
 
@@ -2776,35 +2721,80 @@ msgid "{h}h {m}m {s}s"
 msgstr "{h}e {m}m {s}s"
 
 #: mygpo/web/templatetags/time.py:44
-#, fuzzy, python-brace-format
-#| msgid "{h}h {m}m {s}s"
+#, python-brace-format
 msgid "{m}m {s}s"
-msgstr "{h}e {m}m {s}s"
+msgstr "{m}m {s}s"
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] "%(weeks)d semaine"
 msgstr[1] "%(weeks)d semaines"
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] "%(days)d jour"
 msgstr[1] "%(days)d jours"
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] "%(hours)d heure"
 msgstr[1] "%(hours)d heures"
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "un autre site"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "Démarrer votre annonce"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "Veuillez contacter <a "
+#~ "href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> si vous "
+#~ "souhaitez faire de la publicité sur %(sitename)s ou si vous avez des "
+#~ "questions. Les paiements sont effectués via PayPal à l'adresse "
+#~ "thp@perli.net."
+
+#~ msgid "Login failed."
+#~ msgstr "Échec de la connexion."
+
+#~ msgid "Login with Google is currently not possible."
+#~ msgstr "La connexion avec Google n'est actuellement pas possible."
+
+#, python-brace-format
+#~ msgid ""
+#~ "Your account has been connected with {google}. Open Settings to change "
+#~ "this."
+#~ msgstr ""
+#~ "Votre compte a été connecté avec {google}. Ouvrez les paramètres pour "
+#~ "changer cela."
+
+#, python-format
+#~ msgid ""
+#~ "No account connected with your Google account %s. Please log in to "
+#~ "connect."
+#~ msgstr ""
+#~ "Aucun compte connecté avec votre compte Google %s. Veuillez vous "
+#~ "identifier pour vous connecter."
+
+#~ msgid "Connect"
+#~ msgstr "Connecter"
+
+#~ msgid "Login with Google"
+#~ msgstr "Connectez-vous avec Google"
+
+#~ msgid "Mailing&nbsp;List"
+#~ msgstr "&nbsp;Liste de diffusion"
 
 #~ msgid "Timing"
 #~ msgstr "Minutage"
@@ -2817,13 +2807,14 @@ msgstr "un autre site"
 
 #~ msgid ""
 #~ "If you want to support gpodder.net financially, you can donate via PayPal "
-#~ "to stefan@skoegl.net. You can also send a book via Amazon (<a href="
-#~ "\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://"
-#~ "amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www.amazon.co.uk/"
-#~ "registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "to stefan@skoegl.net. You can also send a book via Amazon (<a "
+#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~ "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~ "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 #~ msgstr ""
 #~ "Si vous souhaitez soutenir financièrement gpodder.net, vous pouvez faire "
 #~ "un don via PayPal à stefan@skoegl.net. Vous pouvez également envoyer un "
-#~ "livre via Amazon (<a href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH"
-#~ "\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> ou <a href="
-#~ "\"http://www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "livre via Amazon (<a href=\"http://www.amazon.de/wishlist/"
+#~ "24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</"
+#~ "a> ou <a href=\"http://www.amazon.co.uk/registry/wishlist/"
+#~ "24JRVURXUKO6F\">UK</a>)."

--- a/mygpo/locale/he/LC_MESSAGES/django.po
+++ b/mygpo/locale/he/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2018-06-20 06:29+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>, 2019\n"
 "Language-Team: Hebrew (https://www.transifex.com/yaron/teams/87581/he/)\n"
@@ -31,7 +31,7 @@ msgstr "הפעלת משתמש"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "שם משתמש"
 
@@ -157,7 +157,7 @@ msgstr "משימות מתוזמנות ב־Celery"
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr "הרשאות הפצה"
 
@@ -193,7 +193,11 @@ msgstr "אם יש לך שאלות, ניתן לבקר ב־%(url)s"
 msgid "Merge Podcasts and Episodes"
 msgstr "מיזוג פודקאסטים ופרקים"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -287,25 +291,37 @@ msgstr "רענון"
 msgid "User-Agent"
 msgstr "סוכן דפדפן"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "אין פודקאסט בכתובת {url}"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr "יש לספק שם משתמש או כתובת דוא״ל"
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr "לא נמצאו משתמשים"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr "המשתמש {username} ‎({email}) עבר עימות"
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} is already activated"
+msgstr "המשתמש {username} ‎({email}) עבר עימות"
+
+#: mygpo/administration/views.py:383
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} data has been archived."
+msgstr "המשתמש {username} ‎({email}) עבר עימות"
+
+#: mygpo/administration/views.py:389
 #, fuzzy, python-brace-format
 #| msgid "User {username} ({email}) activated"
 msgid "Email for {username} ({email}) resent"
@@ -388,11 +404,11 @@ msgstr "תיקיית פודקאסטים"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"%(listtitle)s <span class=\"by-user\">מאת <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">מאת <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -451,8 +467,8 @@ msgstr "הצגת הרישיון"
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "פודקאסט"
 
@@ -475,14 +491,14 @@ msgid "Podcasts with License Information"
 msgstr "פודקאסטים עם פרטי רישיון"
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr "רישיון"
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr "פודקאסטים"
 
@@ -529,7 +545,7 @@ msgid "OK"
 msgstr "אישור"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr "פודקאסט חסר"
 
@@ -560,7 +576,7 @@ msgstr "מימון פודקאסט"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr "רשימות פודקאסטים"
 
@@ -576,6 +592,7 @@ msgstr "משתמש"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "הורדה"
 
@@ -594,8 +611,8 @@ msgstr "יצירת רשימת פודקאסטים על נושא מועדף עלי
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "חיפוש"
 
@@ -627,20 +644,20 @@ msgstr "רשימות מובילות"
 msgid "Client Access"
 msgstr "גישת לקוח"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr "נוספו %d פודקאסטים"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "היסטוריה"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -661,7 +678,7 @@ msgid "Action"
 msgstr "פעולה"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "מכשיר"
 
@@ -671,7 +688,7 @@ msgstr "הוספה"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr "היסטוריית מינויים"
@@ -705,7 +722,7 @@ msgstr "עכשיו"
 msgid "Earlier"
 msgstr "מוקדם יותר"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr "אין היסטוריה עדיין"
 
@@ -785,16 +802,16 @@ msgstr "רשימות פודקאסטים מאת %(username)s"
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "לא נוצרו עדיין רשימות פודקאסטים על ידי המשתמש %(username)s."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr "עליך לציין כותרת."
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr "„{title}” אינה כותרת תקנית"
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr "תודה לך על הדירוג!"
 
@@ -834,24 +851,24 @@ msgstr "הוספה למועדפים"
 msgid "Episode History"
 msgstr "היסטוריית פרקים"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "פודקאסט ללא שם"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr "מאת"
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr "הזנה"
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr "מנויים"
@@ -916,9 +933,9 @@ msgstr "יש להחליף את השדה ‚YOUR_ADRESS’ בכתובת הזנת 
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "פרסום"
 
@@ -985,21 +1002,6 @@ msgstr ""
 "שמחפשים באופן פעיל פודקאסטים מעניינים. עם זאת, איננו מתחייבים למספר מסוים של "
 "מבקרים במהלך תקופת הפרסום שלך."
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "התחלת הפרסום שלך"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"עליך ליצור קשר עם <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</"
-"a> אם ברצונך לפרסם באתר %(sitename)s או אם יש לך שאלות. התשלום הוא דרך "
-"PayPal לטובת thp@perli.net."
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "פרק ללא שם"
@@ -1022,7 +1024,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr "שמירה"
@@ -1041,7 +1043,7 @@ msgstr "חזרה לעמוד הפודקאסט"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "פרקים"
 
@@ -1126,8 +1128,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 "ניתן למצוא פרטים נוספים ב<a href=\"%(advertise-url)s\">עמוד הפרסומות</a>."
 
@@ -1147,8 +1149,8 @@ msgstr ""
 #| "podcast listed on %(sitename)s, feel free to apply by sending a mail "
 #| "with\n"
 #| "  <ul>\n"
-#| "   <li>your username on %(sitename)s (<a href=\"%(register-url)s"
-#| "\">register if you don't have one</a>)</li>\n"
+#| "   <li>your username on %(sitename)s (<a "
+#| "href=\"%(register-url)s\">register if you don't have one</a>)</li>\n"
 #| "   <li>the name and URL of the podcast you are publishing</li>\n"
 #| "   <li>an email address that is visible somewhere on the podcast's "
 #| "website (to legitimate you)\n"
@@ -1241,8 +1243,8 @@ msgstr ""
 msgid "Update now"
 msgstr "עדכון כעת"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr "טוויטר"
 
@@ -1261,9 +1263,9 @@ msgid ""
 "p/pubsubhubbub/\">PubSubHubbu</a> hub, %(sitename)s can immediatelly update "
 "your podcast when a new episode is released."
 msgstr ""
-"על ידי פרסום הזנת הפודקאסטים שלך דרך נקודת הריכוז <a href=\"https://code."
-"google.com/p/pubsubhubbub/\">PubSubHubbu</a>, ל־%(sitename)s יש אפשרות לעדכן "
-"את הפודקאסט שלך ברגע שפרק חדש מופץ."
+"על ידי פרסום הזנת הפודקאסטים שלך דרך נקודת הריכוז <a href=\"https://"
+"code.google.com/p/pubsubhubbub/\">PubSubHubbu</a>, ל־%(sitename)s יש אפשרות "
+"לעדכן את הפודקאסט שלך ברגע שפרק חדש מופץ."
 
 #: mygpo/publisher/templates/publisher/podcast.html:157
 #, python-format
@@ -1307,8 +1309,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 "מצאנו את הרישיון הבא בפודקאסט שלך: <a href=\"%(license)s\">%(license)s</a>"
 
@@ -1320,9 +1322,9 @@ msgid ""
 "include license information."
 msgstr ""
 "לא מצאנו רישיון בהזנת הפודקאסט שלך. יש לפנות אל <a href=\"https://github.com/"
-"gpodder/podcast-feed-best-practice/blob/master/podcast-feed-best-practice."
-"md#license\">ההמלצות להזנות פודקאסטים של gPodder</a> על כיצד מוטב להוסיף "
-"פרטי רישיון."
+"gpodder/podcast-feed-best-practice/blob/master/podcast-feed-best-"
+"practice.md#license\">ההמלצות להזנות פודקאסטים של gPodder</a> על כיצד מוטב "
+"להוסיף פרטי רישיון."
 
 #: mygpo/publisher/templates/publisher/podcast.html:208
 msgid "Link"
@@ -1332,21 +1334,21 @@ msgstr "קישור"
 msgid "Show Group Stats"
 msgstr "הצגת סטטיסטיקה קבוצתית"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr "תוזמן עדכון. יכול להיות שיחלוף קצת זמן עד שניתן יהיה לראות תוצאות."
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr "נתונים עודכנו"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr "אסימון מפרסם עודכן"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr "הוסר השם המופשט {slug} מהפרק {episode}"
@@ -1419,8 +1421,8 @@ msgstr "שיתוף"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "מינויים"
 
@@ -1435,7 +1437,7 @@ msgid "User Page"
 msgstr "דף משתמש"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "הגדרות"
 
@@ -1554,9 +1556,9 @@ msgstr "%(episode_count)s פרקים"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 "אין לך מינויים עדיין. עליך להגדיר את <a href=\"%(devices)s\">לקוח "
 "הפודקאסטים</a> שלך ואת <a href=\"%(directory)s\">איתור פודקאסטים מעניינים</"
@@ -1568,22 +1570,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr "הורדת OPML"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "מינויי הפודקאסטים של %(username)s ב־%(site)s"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr "השינויים האחרונים למינויי הפודקאסטים של %(username)s תחת %(site)s"
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "הרשמה אל %(podcast)s מצד %(username)s (%(site)s)"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "ביטול הרשמה אל %(podcast)s מצד %(username)s (%(site)s)"
@@ -1601,27 +1603,27 @@ msgstr "אין עניין"
 msgid "No Suggestions Yet"
 msgstr "אין הצעות עדיין"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "מחשב שולחני"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "מחשב נייד"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "טלפון סלולרי"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "שרת"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr "מחשב לוח"
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "אחר"
 
@@ -1656,9 +1658,9 @@ msgid "You are already registered."
 msgstr "כבר נרשמת."
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "הרשמה"
 
@@ -1741,126 +1743,118 @@ msgstr "לא ניתן להעלות מינויים: {err}"
 msgid "Your subscription will be updated in a moment."
 msgstr "המינוי שלך יתעדכן בעוד רגע קט."
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr "שם המשתמש או כתובת הדוא״ל כבר נמצאים בשימוש"
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr "קישור ההפעלה שגוי או שתוקפו פג."
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr "המשתמש שלך הופעל. כעת יתאפשר לך להיכנס."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr "נדרשים שם משתמש או כתובת דוא״ל."
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "משתמש לא קיים."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your account has been deleted"
+msgid "Your data has been archived."
+msgstr "חשבונך נמחק"
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "החשבון שלך כבר הופעל. אפשר לנסות להיכנס לחשבון."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr "אופס! משהו השתבש. נא לבדוק שנית את המידע שהקלדת."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr "חשבונך נותק"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr "חסר שם משתמש"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr "חסרה ססמה"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "שם משתמש או ססמה שגויים."
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 "נא להפעיל את החשבון שלך תחילה. הרגע שלחנו לך את הודעת ההפעלה בדוא״ל מחדש"
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr "הכניסה נכשלה."
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr "הכניסה עם Google אינה אפשרית כרגע."
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr "החשבון שלך התחבר עם {google}. ניתן לפתוח את ההגדרות כדי לשנות את זה."
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr "אף חשבון לא התחבר לחשבון שלך ב־Google %s. נא להיכנס כדי להתחבר."
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "כתובת דוא״ל"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "ססמה נוכחית"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "ססמה חדשה"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "אימות ססמה"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr "כמה מילים עליך"
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "שם"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "סוג"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "מזהה מכשיר"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr "מזהה על המכשיר"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "שיתוף המינוי הזה עם משתמשים אחרים (ציבורי)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "לא נבחר מכשיר"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "נא להקליד את שם המשתמש שלך"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "או את כתובת הדוא״ל בה השתמשת בעת ההרשמה"
 
@@ -1902,110 +1896,97 @@ msgstr "מחובר עם %(gmail)s"
 msgid "Disconnect"
 msgstr "ניתוק"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr "חיבור"
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "חשבון"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "כניסה"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr "כניסה עם Google"
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "עיון"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "ספרייה"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr "תמיכה"
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr "מסמכים"
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr "קבוצת&nbsp;דיונים"
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr "שאלות"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr "להביע&nbsp;תמיכה&nbsp;בנו"
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr "תרומה"
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr "לעקוב"
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr "בלוג"
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr "בלוג&nbsp;(RSS)"
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr "פיתוח"
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr "API"
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "ספריות"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr "לקוחות"
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr "פרסום"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr "קבלת&nbsp;גישה"
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr "קישור&nbsp;אלינו"
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr "האירוח סופק על ידי tornadovps.com"
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr "תרומה"
 
@@ -2027,24 +2008,31 @@ msgid "Work"
 msgstr "עבודה"
 
 #: mygpo/web/templates/contribute.html:19
+#, fuzzy
+#| msgid ""
+#| "If you want to contribute to gpodder.net by writing code, check out the "
+#| "<a href=\"/developer/\">Development</a> page. We also appreciate "
+#| "contributions of non-coding work, such as web and interface design, "
+#| "server operations, testing, etc. If you are interested, join the <a "
+#| "href=\"https://gpodder.github.io/docs/mailing-list.html\">mailing list</"
+#| "a> or the IRC channel #gpodder on chat.freenode.net."
 msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 "אם מעניין אותך להתנדב לטובת gpodder.net עם כתיבת קוד, כדאי לבקר בעמוד <a "
 "href=\"/developer/\">פיתוח</a>. אנו גם מעריכים צורות התנדבות שאינן בצורת "
 "קוד, כגון עיצוב האתר, פעולות בשרת, בדיקות וכו׳. אם כל זה מעניין אותך, "
-"באפשרותך להצטרף ל<a href=\"https://gpodder.github.io/docs/mailing-list.html"
-"\">רשימת הדיונים</a> או לערוץ ה־IRC בשם ‎#gpodder תחת chat.freenode.net."
+"באפשרותך להצטרף ל<a href=\"https://gpodder.github.io/docs/mailing-"
+"list.html\">רשימת הדיונים</a> או לערוץ ה־IRC בשם ‎#gpodder תחת "
+"chat.freenode.net."
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2075,7 +2063,7 @@ msgstr "כן"
 msgid "No"
 msgstr "לא"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "סקירה"
 
@@ -2091,21 +2079,25 @@ msgstr "הפרקים החדשים ביותר"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
-"ברוך בואך אל %(site)s! אם זה הביקור הראשון שלך, כדאי לך להגדיר את <a href="
-"\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html\">לקוח "
+"ברוך בואך אל %(site)s! אם זה הביקור הראשון שלך, כדאי לך להגדיר את <a "
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html\">לקוח "
 "הפודקאסטים</a> שלך ולנסות לחקור כמה שיותר תיבות <em>סיור</em> שאפשר."
 
 #: mygpo/web/templates/dashboard.html:44
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
+#| "ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-"
+#| "list.html\">mailing list</a> or <a href=\"https://github.com/gpodder/"
+#| "mygpo/issues\">forum</a>."
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 "במקרה של תקלות, מוטב לעיין ב<a href=\"%(help)s\">מסמכים</a> או לשאול שאלות "
 "ב<a href=\"https://gpodder.github.io/docs/mailing-list.html\">רשימת הדיונים</"
@@ -2199,7 +2191,7 @@ msgid "Thanks"
 msgstr "תודות"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr "פיתוח"
 
@@ -2212,8 +2204,9 @@ msgstr "שירות מקוון"
 #| msgid ""
 #| "The sourcecode of the webservice gpodder.net is released as open source "
 #| "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted "
-#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://bugs.gpodder."
-#| "org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
+#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://"
+#| "bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</"
+#| "a>."
 msgid ""
 "The sourcecode of the webservice gpodder.net is released as open source "
 "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted at "
@@ -2245,9 +2238,9 @@ msgid ""
 "as examples. <a href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
 "clients.html\">See list of clients.</a>"
 msgstr ""
-"כבר ישנם מגוון לקוחות לפלטפורמות שונות בהם ניתן להשתמש כדוגמאות. <a href="
-"\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html\">הצגת רשימת "
-"הלקוחות.</a>"
+"כבר ישנם מגוון לקוחות לפלטפורמות שונות בהם ניתן להשתמש כדוגמאות. <a "
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html\">הצגת "
+"רשימת הלקוחות.</a>"
 
 #: mygpo/web/templates/device-edit.html:11 mygpo/web/templates/device.html:11
 #, python-format
@@ -2336,13 +2329,13 @@ msgstr "לא מסונכרן"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
-"לא מוגדרים עבורך מכשירים עדיין. נא לעבור לעמוד ה<a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">לקוחות</a> כדי ללמוד איך להגדיר "
-"את יישומי הלקוח שלך."
+"לא מוגדרים עבורך מכשירים עדיין. נא לעבור לעמוד ה<a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">לקוחות</a> כדי ללמוד "
+"איך להגדיר את יישומי הלקוח שלך."
 
 #: mygpo/web/templates/devicelist.html:74
 msgid "Deleted Devices"
@@ -2357,7 +2350,7 @@ msgid "Delete Permanently"
 msgstr "מחיקה לצמיתות"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "פרקים מועדפים"
 
@@ -2383,18 +2376,18 @@ msgstr ""
 "פשוט לחכות מעט ולנסות שוב!"
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "התגיות שלי"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"לא תייגת אף פודקאסט עדיין. יש לגשת אל ה<a href=\"%(subscriptions-url)s"
-"\">מינויים</a> שלך ולתייג כמה מהם."
+"לא תייגת אף פודקאסט עדיין. יש לגשת אל ה<a "
+"href=\"%(subscriptions-url)s\">מינויים</a> שלך ולתייג כמה מהם."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2407,11 +2400,11 @@ msgstr "הססמה שלך עברה איפוס"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
-"אמורה הייתה להגיע אליך הודעה עם הססמה החדשה שלך. נא <a href=\"%(login-url)s"
-"\">להיכנס</a> כעת."
+"אמורה הייתה להגיע אליך הודעה עם הססמה החדשה שלך. נא <a "
+"href=\"%(login-url)s\">להיכנס</a> כעת."
 
 #: mygpo/web/templates/password_reset_failed.html:4
 msgid "Password could not be reset"
@@ -2470,7 +2463,7 @@ msgstr "מינויים פרטיים"
 msgid "Make Public"
 msgstr "חשיפה לציבור"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr "מדיניות פרטיות"
 
@@ -2516,6 +2509,17 @@ msgid ""
 msgstr ""
 "כיוון שאנו מציגים שמות לאחר אחזור המידע מההזנה -- פעולה שעשויה לארוך זמן מה. "
 "עד להשלמת פעולה זו, הפודקאסט פשוט ייקרא כך."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Activate User"
+msgid "Archived User"
+msgstr "הפעלת משתמש"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2670,47 +2674,51 @@ msgstr "הפרק נמחק"
 msgid "Unknown Episode"
 msgstr "פרק לא ידוע"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "בית"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "עזרה"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "מינויי המשתמש"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "הצעות"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr "תכונות"
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr "רשימות מובילות"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "התקנים"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr "קהילה"
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr "עמוד המשתמש שלי"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "פרטיות"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "מעבר אל gpodder.net"
 
@@ -2725,7 +2733,7 @@ msgstr "{h} שע׳ {m} דק׳ {s} שנ׳"
 msgid "{m}m {s}s"
 msgstr "{h} שע׳ {m} דק׳ {s} שנ׳"
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
@@ -2734,7 +2742,7 @@ msgstr[1] "שבועיים"
 msgstr[2] "%(weeks)d שבועות"
 msgstr[3] "%(weeks)d שבועות"
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
@@ -2743,7 +2751,7 @@ msgstr[1] "יומיים"
 msgstr[2] "%(days)d ימים"
 msgstr[3] "%(days)d ימים"
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
@@ -2752,9 +2760,51 @@ msgstr[1] "שעתיים"
 msgstr[2] "%(hours)d שעות"
 msgstr[3] "%(hours)d שעות"
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "אתר אחר"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "התחלת הפרסום שלך"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "עליך ליצור קשר עם <a "
+#~ "href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> אם ברצונך לפרסם "
+#~ "באתר %(sitename)s או אם יש לך שאלות. התשלום הוא דרך PayPal לטובת "
+#~ "thp@perli.net."
+
+#~ msgid "Login failed."
+#~ msgstr "הכניסה נכשלה."
+
+#~ msgid "Login with Google is currently not possible."
+#~ msgstr "הכניסה עם Google אינה אפשרית כרגע."
+
+#, python-brace-format
+#~ msgid ""
+#~ "Your account has been connected with {google}. Open Settings to change "
+#~ "this."
+#~ msgstr ""
+#~ "החשבון שלך התחבר עם {google}. ניתן לפתוח את ההגדרות כדי לשנות את זה."
+
+#, python-format
+#~ msgid ""
+#~ "No account connected with your Google account %s. Please log in to "
+#~ "connect."
+#~ msgstr "אף חשבון לא התחבר לחשבון שלך ב־Google %s. נא להיכנס כדי להתחבר."
+
+#~ msgid "Connect"
+#~ msgstr "חיבור"
+
+#~ msgid "Login with Google"
+#~ msgstr "כניסה עם Google"
+
+#~ msgid "Mailing&nbsp;List"
+#~ msgstr "קבוצת&nbsp;דיונים"
 
 #~ msgid "Timing"
 #~ msgstr "תזמון"
@@ -2767,13 +2817,13 @@ msgstr "אתר אחר"
 
 #~ msgid ""
 #~ "If you want to support gpodder.net financially, you can donate via PayPal "
-#~ "to stefan@skoegl.net. You can also send a book via Amazon (<a href="
-#~ "\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://"
-#~ "amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www.amazon.co.uk/"
-#~ "registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "to stefan@skoegl.net. You can also send a book via Amazon (<a "
+#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~ "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~ "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 #~ msgstr ""
 #~ "אם ברצונך לתמוך ב־gpodder.net כלכלית, ניתן לתרום דרך PayPal לטובת "
-#~ "stefan@skoegl.net. ניתן גם לשלוח ספר דרך Amazon (<a href=\"http://www."
-#~ "amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/"
+#~ "stefan@skoegl.net. ניתן גם לשלוח ספר דרך Amazon (<a href=\"http://"
+#~ "www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/"
 #~ "w/3IPIF4J4F2C5R\">US</a> או <a href=\"http://www.amazon.co.uk/registry/"
 #~ "wishlist/24JRVURXUKO6F\">UK</a>)."

--- a/mygpo/locale/it/LC_MESSAGES/django.po
+++ b/mygpo/locale/it/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2018-10-28 18:17+0000\n"
 "Last-Translator: Enrico B. <enricobe@hotmail.com>, 2018\n"
 "Language-Team: Italian (https://www.transifex.com/gpoddernet/teams/93001/"
@@ -32,7 +32,7 @@ msgstr "Attiva utente"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Username"
 
@@ -158,7 +158,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr "Permessi di pubblicazione"
 
@@ -195,7 +195,11 @@ msgstr "Per qualsiasi domanda, visita %(url)s"
 msgid "Merge Podcasts and Episodes"
 msgstr "Unisci podcast e episodi"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -285,25 +289,37 @@ msgstr "Aggiorna"
 msgid "User-Agent"
 msgstr "User-Agent"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "Nessun podcast con l'URL {url}"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr "Inserisci username o indirizzo email"
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr "Nessun utente trovato"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr "Utente {username} ({email}) attivato"
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} is already activated"
+msgstr "Utente {username} ({email}) attivato"
+
+#: mygpo/administration/views.py:383
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} data has been archived."
+msgstr "Utente {username} ({email}) attivato"
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr "Email per {username} ({email}) reinviata"
@@ -385,11 +401,11 @@ msgstr "Raccolte di podcast"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"%(listtitle)s <span class=\"by-user\">di <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">di <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -448,8 +464,8 @@ msgstr "Dettagli licenza"
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podcast"
 
@@ -472,14 +488,14 @@ msgid "Podcasts with License Information"
 msgstr "Podcast con informazioni sulla licenza"
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr "Licenze"
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr "Podcast"
 
@@ -526,7 +542,7 @@ msgid "OK"
 msgstr "OK"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr "Aggiungi podcast"
 
@@ -558,7 +574,7 @@ msgstr "Sponsorizzazione podcast"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr "Liste podcast"
 
@@ -574,6 +590,7 @@ msgstr "Utente"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "Scarica"
 
@@ -592,8 +609,8 @@ msgstr "Crea una lista di podcast su un argomento che ti piace"
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Cerca"
 
@@ -626,20 +643,20 @@ msgstr "Classifica"
 msgid "Client Access"
 msgstr "Sottoscrizione client"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr "%d podcast aggiunti"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Cronologia"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -660,7 +677,7 @@ msgid "Action"
 msgstr "Azione"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Strumento tecnico"
 
@@ -670,7 +687,7 @@ msgstr "Aggiungi"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr "Cronologia sottoscrizione"
@@ -704,7 +721,7 @@ msgstr "Ora"
 msgid "Earlier"
 msgstr "Prima"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr "Nessuna cronologia"
 
@@ -784,16 +801,16 @@ msgstr "Lista podcast di %(username)s"
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s non ha ancora creato nessuna lista podcast."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr "Devi specificare un titolo."
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr "\"{title}\" non è un titolo valido."
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr "Grazie per la valutazione!"
 
@@ -833,24 +850,24 @@ msgstr "Preferito"
 msgid "Episode History"
 msgstr "Cronologia episodi"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Podcast senza nome"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr "di"
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr "Feed"
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr "abbonati"
@@ -916,9 +933,9 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "Pubblicizza"
 
@@ -989,21 +1006,6 @@ msgstr ""
 "modo non possiamo garantirti un numero definito di visitatori durante il "
 "periodo della tua campagna. "
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "Avvia la tua campagna"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"Scrivi a <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> se "
-"vuoi fare promozione su %(sitename)s o se hai qualsiasi domanda. I pagamenti "
-"vengono effettuati tramite PayPal a thp@perli.net."
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "Episodio senza nome"
@@ -1027,7 +1029,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr "Salva"
@@ -1046,7 +1048,7 @@ msgstr "Torna alla Pagina del podcast"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Episodi"
 
@@ -1134,8 +1136,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 "Puoi trovare dettagli aggiuntivi nella <a href=\"%(advertise-url)s\">pagina "
 "pubblicitaria</a>."
@@ -1156,8 +1158,8 @@ msgstr ""
 #| "podcast listed on %(sitename)s, feel free to apply by sending a mail "
 #| "with\n"
 #| "  <ul>\n"
-#| "   <li>your username on %(sitename)s (<a href=\"%(register-url)s"
-#| "\">register if you don't have one</a>)</li>\n"
+#| "   <li>your username on %(sitename)s (<a "
+#| "href=\"%(register-url)s\">register if you don't have one</a>)</li>\n"
 #| "   <li>the name and URL of the podcast you are publishing</li>\n"
 #| "   <li>an email address that is visible somewhere on the podcast's "
 #| "website (to legitimate you)\n"
@@ -1178,8 +1180,8 @@ msgstr ""
 "Le Pagine dell'editore sono in Beta, ma se stai pubblicando un podcast già "
 "elencato su %(sitename)s, puoi fare richiesta inviando una mail con\n"
 "  <ul>\n"
-"   <li>il tuo nome utente su %(sitename)s (<a href=\"%(register-url)s"
-"\">registrati se non ne hai uno</a>)</li>\n"
+"   <li>il tuo nome utente su %(sitename)s (<a "
+"href=\"%(register-url)s\">registrati se non ne hai uno</a>)</li>\n"
 "   <li>il nome e l'URL del podcast che pubblichi</li>\n"
 "   <li>un indirizzo email visibile da qualche parte sul sito (per "
 "legittimarti)\n"
@@ -1249,8 +1251,8 @@ msgstr "Errore"
 msgid "Update now"
 msgstr "Aggiorna ora"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -1318,11 +1320,11 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
-"Abbiamo rilevato questa licenza nel tuo podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"Abbiamo rilevato questa licenza nel tuo podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
 msgid ""
@@ -1331,10 +1333,10 @@ msgid ""
 "practice.md#license\"> gPodder Podcast Feed Best Practice</a> on how to "
 "include license information."
 msgstr ""
-"Non abbiamo rilevato alcuna licenza nel tuo feed. Fai riferimento a <a href="
-"\"https://github.com/gpodder/podcast-feed-best-practice/blob/master/podcast-"
-"feed-best-practice.md#license\"> gPodder Podcast Feed Best Practice</a> per "
-"includere le informazioni di licenza."
+"Non abbiamo rilevato alcuna licenza nel tuo feed. Fai riferimento a <a "
+"href=\"https://github.com/gpodder/podcast-feed-best-practice/blob/master/"
+"podcast-feed-best-practice.md#license\"> gPodder Podcast Feed Best Practice</"
+"a> per includere le informazioni di licenza."
 
 #: mygpo/publisher/templates/publisher/podcast.html:208
 msgid "Link"
@@ -1344,7 +1346,7 @@ msgstr "Link"
 msgid "Show Group Stats"
 msgstr "Mostra statistiche di gruppo"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
@@ -1352,15 +1354,15 @@ msgstr ""
 "L'aggiornamento è stato schedulato. Potrebbe volerci del tempo prima che i "
 "risultati siano visibili."
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr "Dati aggiornati"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr "Token di pubblicazione aggiornato"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr "Rimosso slug {slug} da {episode}"
@@ -1433,8 +1435,8 @@ msgstr "Condividi"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Sottoscrizioni"
 
@@ -1449,7 +1451,7 @@ msgid "User Page"
 msgstr "Profilo utente"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -1570,13 +1572,13 @@ msgstr "%(episode_count)s episodi"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
-"Non hai ancora nessuna sottoscrizione. Imposta i tuoi <a href=\"%(devices)s"
-"\">client podcast</a> e <a href=\"%(directory)s\">scopri podcast "
-"interessanti</a>."
+"Non hai ancora nessuna sottoscrizione. Imposta i tuoi <a "
+"href=\"%(devices)s\">client podcast</a> e <a href=\"%(directory)s\">scopri "
+"podcast interessanti</a>."
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
 #: mygpo/suggestions/templates/suggestions.html:54
@@ -1584,22 +1586,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr "Scarica OPML"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "Sottoscrizioni podcast di %(username)s su %(site)s"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr "Modifiche recenti al podcast di %(username)s su %(site)s"
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "%(username)s abbonato a %(podcast)s (%(site)s)"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "%(username)s disiscritto da %(podcast)s (%(site)s)"
@@ -1617,27 +1619,27 @@ msgstr "Nessun interesse"
 msgid "No Suggestions Yet"
 msgstr "Ancora nessun suggerimento"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Desktop"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Laptop"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Telefono"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Server"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr "Tablet"
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Altro"
 
@@ -1673,9 +1675,9 @@ msgid "You are already registered."
 msgstr "Sei già registrato."
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Registrati"
 
@@ -1697,8 +1699,8 @@ msgid ""
 "If it doesn't arrive, you can <a href=\"%(resend-activation-url)s\">resend</"
 "a> it."
 msgstr ""
-"Se non dovessi riceverla, puoi <a href=\"%(resend-activation-url)s"
-"\">rispedirla</a>."
+"Se non dovessi riceverla, puoi <a "
+"href=\"%(resend-activation-url)s\">rispedirla</a>."
 
 #: mygpo/users/templates/registration/resend_activation.html:4
 #: mygpo/users/templates/registration/resend_activation.html:8
@@ -1757,52 +1759,64 @@ msgstr "Impossibile caricare le sottoscrizioni: {err}"
 msgid "Your subscription will be updated in a moment."
 msgstr "Le tue sottoscrizioni saranno aggiornate in pochi istanti."
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr "Username o indirizzo email già in uso"
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr "Il link di attivazione non è valido o è già scaduto."
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr "Il tuo utente è stato attivato. Puoi effettuare il login."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr "Username o indirizzo email richiesto."
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "L'utente non esiste."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your account has been deleted"
+msgid "Your data has been archived."
+msgstr "Il tuo account è stato eliminato"
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "Il tuo account è già stato attivato. Procedi ed effettua il login."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 "Oops! Qualcosa è andato storto. Per favore ricontrolla i dati inseriti."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr "Il tuo account è stato disconesso."
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr "Username mancante"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr "Password mancante"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Username o password errati."
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
@@ -1810,79 +1824,55 @@ msgstr ""
 "Per favore prima attiva il tuo account. Ti abbiamo appena rispedito l'email "
 "di attivazione."
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr "Login fallito."
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr "Al momento non è possibile fare il login con Google."
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-"Il tuo account è stato connesso con {google}. Apri le impostazioni per "
-"modificare."
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-"Nessun account connesso con il tuo account Google %s. Fai il login per "
-"connetterlo."
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "Indirizzo e-mail"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Password attuale"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Nuova password"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "Conferma password"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr "Alcune parole su di te"
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Nome"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Tipo"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "ID dispositivo"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr "ID del dispositivo"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "Condividi questa sottoscrizione con altri utenti (public)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Nessun dispositivo selezionato"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Inserisci il tuo username"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "o l'indirizzo email usato per la registrazione"
 
@@ -1924,110 +1914,97 @@ msgstr "Connesso con %(gmail)s"
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr "Connetti"
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "Account"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Accedi"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr "Login con Google"
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Esplora"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "Raccolte"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr "Supporto"
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr "Docs"
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr "Mailing&nbsp;List"
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr "Domande"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr "Supportaci"
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr "Dona"
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr "Seguici"
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr "Blog"
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr "Blog&nbsp;(RSS)"
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr "Sviluppa"
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr "API"
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "Librerie"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr "Client"
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr "Pubblica"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr "Ottieni&nbsp;Accesso"
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr "Collegati&nbsp;A&nbsp;Noi"
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr "hosting fornito da tornadovps.com"
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr "Contribuisci"
 
@@ -2050,13 +2027,19 @@ msgid "Work"
 msgstr "Lavoro"
 
 #: mygpo/web/templates/contribute.html:19
+#, fuzzy
+#| msgid ""
+#| "If you want to contribute to gpodder.net by writing code, check out the "
+#| "<a href=\"/developer/\">Development</a> page. We also appreciate "
+#| "contributions of non-coding work, such as web and interface design, "
+#| "server operations, testing, etc. If you are interested, join the <a "
+#| "href=\"https://gpodder.github.io/docs/mailing-list.html\">mailing list</"
+#| "a> or the IRC channel #gpodder on chat.freenode.net."
 msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 "Se vuoi contribuire a gpodder.net  scrivendo del codice controlla la pagina "
 "<a href=\"/developer/\">Sviluppo</a>. Apprezziamo molto anche altre "
@@ -2067,8 +2050,8 @@ msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2100,7 +2083,7 @@ msgstr "Si"
 msgid "No"
 msgstr "No"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "Panoramica"
 
@@ -2116,21 +2099,26 @@ msgstr "Episodi recenti"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 "Benvenuto su %(site)s! Se è la tua prima visita, dovresti impostare il tuo "
-"<a href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">client podcast</a> e visitare quante più voci <em>Esplora</em> possibile."
+"<a href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">client podcast</a> e visitare quante più voci <em>Esplora</"
+"em> possibile."
 
 #: mygpo/web/templates/dashboard.html:44
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
+#| "ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-"
+#| "list.html\">mailing list</a> or <a href=\"https://github.com/gpodder/"
+#| "mygpo/issues\">forum</a>."
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 "Se hai problemi, dai un'occhiata alla <a href=\"%(help)s\">documentazione</"
 "a> o poni domande nella <a href=\"https://gpodder.github.io/docs/mailing-"
@@ -2225,7 +2213,7 @@ msgid "Thanks"
 msgstr "Grazie"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr "Sviluppo"
 
@@ -2238,8 +2226,9 @@ msgstr "Servizio web"
 #| msgid ""
 #| "The sourcecode of the webservice gpodder.net is released as open source "
 #| "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted "
-#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://bugs.gpodder."
-#| "org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
+#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://"
+#| "bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</"
+#| "a>."
 msgid ""
 "The sourcecode of the webservice gpodder.net is released as open source "
 "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted at "
@@ -2248,8 +2237,8 @@ msgid ""
 msgstr ""
 "Il codice sorgente del sito gpodder.net è rilasciato come open source sotto "
 "licenza AGPLv3 e <a href=\"https://github.com/gpodder/mygpo\">ospitato su "
-"GitHub</a>. I bug possono essere segnalati sul <a href=\"https://bugs."
-"gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
+"GitHub</a>. I bug possono essere segnalati sul <a href=\"https://"
+"bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
 
 #: mygpo/web/templates/developer.html:21
 msgid "Integrating Clients"
@@ -2363,9 +2352,9 @@ msgstr "Non sincronizzato"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 "Non hai ancora alcun dispositivo. Vai alla pagina <a href=\"https://"
 "gpoddernet.readthedocs.io/en/latest/user/clients.html\">client</a> per "
@@ -2384,7 +2373,7 @@ msgid "Delete Permanently"
 msgstr "Elimina definitivamente"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "Episodi preferiti"
 
@@ -2410,18 +2399,18 @@ msgstr ""
 "minuti. Attendi un istante e riprova!"
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "Miei tag"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"Non hai taggato nessun podcast. Vai alle <a href=\"%(subscriptions-url)s"
-"\">sottoscrizioni</a> e taggane alcuni."
+"Non hai taggato nessun podcast. Vai alle <a "
+"href=\"%(subscriptions-url)s\">sottoscrizioni</a> e taggane alcuni."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2434,8 +2423,8 @@ msgstr "La tua password è stata resettata"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 "Dovresti aver ricevuto una email con la nuova passowrd. Per favore, fai il "
 "<a href=\"%(login-url)s\">log in</a> ora."
@@ -2498,7 +2487,7 @@ msgstr "Sottoscrizioni private"
 msgid "Make Public"
 msgstr "Rendi Pubblico"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
@@ -2536,6 +2525,17 @@ msgstr ""
 "Mostriamo i nomi dopo aver raccolto le informazioni dal feed e questo può "
 "richiedere del tempo. Finché ciò non viene completato, il podcast rimane "
 "nominato in questo modo."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Activate User"
+msgid "Archived User"
+msgstr "Attiva utente"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2690,47 +2690,51 @@ msgstr "Questo episodio è stato cancellato"
 msgid "Unknown Episode"
 msgstr "Episodio sconosciuto"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Home"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Aiuto"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "Sottoscrizioni dell'utente"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Suggerimenti"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr "Funzionalità"
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr "Classifiche"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Dispositivi"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr "Community"
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr "La mia pagina"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Privacy"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "Link a gpodder.net"
 
@@ -2744,48 +2748,92 @@ msgstr "{h}h {m}m {s}s"
 msgid "{m}m {s}s"
 msgstr "{m}m {s}s"
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] "%(weeks)d settimana"
 msgstr[1] "%(weeks)d settimane"
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] "%(days)d giorno"
 msgstr[1] "%(days)d giorni"
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] "%(hours)d ora"
 msgstr[1] "%(hours)d ore"
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "altro sito"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "Avvia la tua campagna"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "Scrivi a <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> se "
+#~ "vuoi fare promozione su %(sitename)s o se hai qualsiasi domanda. I "
+#~ "pagamenti vengono effettuati tramite PayPal a thp@perli.net."
+
+#~ msgid "Login failed."
+#~ msgstr "Login fallito."
+
+#~ msgid "Login with Google is currently not possible."
+#~ msgstr "Al momento non è possibile fare il login con Google."
+
+#, python-brace-format
+#~ msgid ""
+#~ "Your account has been connected with {google}. Open Settings to change "
+#~ "this."
+#~ msgstr ""
+#~ "Il tuo account è stato connesso con {google}. Apri le impostazioni per "
+#~ "modificare."
+
+#, python-format
+#~ msgid ""
+#~ "No account connected with your Google account %s. Please log in to "
+#~ "connect."
+#~ msgstr ""
+#~ "Nessun account connesso con il tuo account Google %s. Fai il login per "
+#~ "connetterlo."
+
+#~ msgid "Connect"
+#~ msgstr "Connetti"
+
+#~ msgid "Login with Google"
+#~ msgstr "Login con Google"
+
+#~ msgid "Mailing&nbsp;List"
+#~ msgstr "Mailing&nbsp;List"
 
 #, fuzzy
 #~| msgid ""
 #~| "If you want to support gpodder.net financially, you can donate via "
 #~| "PayPal to stefan@skoegl.net. You can also send a book via Amazon (<a "
-#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href="
-#~| "\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www."
-#~| "amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~| "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~| "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 #~ msgid ""
 #~ "If you want to support gpodder.net financially, you can donate via <a "
 #~ "href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>. You can also "
-#~ "send a book via Amazon (<a href=\"http://www.amazon.de/"
-#~ "wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R"
-#~ "\">US</a> or <a href=\"http://www.amazon.co.uk/registry/"
-#~ "wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "send a book via Amazon (<a href=\"http://www.amazon.de/wishlist/"
+#~ "24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</"
+#~ "a> or <a href=\"http://www.amazon.co.uk/registry/wishlist/"
+#~ "24JRVURXUKO6F\">UK</a>)."
 #~ msgstr ""
 #~ "Se desideri supportare finanziariamente gpodder.net, puoi donare tramite "
 #~ "PayPal a stefan@skoegl.net. Puoi anche inviare un libro via Amazon (<a "
-#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href="
-#~ "\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www.amazon."
-#~ "co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~ "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~ "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."

--- a/mygpo/locale/ko/LC_MESSAGES/django.po
+++ b/mygpo/locale/ko/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mygpo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2017-07-06 17:10+0900\n"
 "Last-Translator: Changwoo Ryu <cwryu@debian.org>\n"
 "Language-Team: Changwoo Ryu <cwryu@debian.org>\n"
@@ -25,7 +25,7 @@ msgstr "다시 활성화"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "사용자 이름"
 
@@ -155,7 +155,7 @@ msgstr "예정된 Celery 작업"
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 #, fuzzy
 #| msgid "Publisher Pages"
 msgid "Publisher Permissions"
@@ -195,7 +195,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr "팟캐스트 및 에피소드 병합"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -295,27 +299,37 @@ msgstr "새로 고침"
 msgid "User-Agent"
 msgstr "User-Agent"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "{url} URL의 팟캐스트 없음"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 #, fuzzy
 #| msgid "Nothing found"
 msgid "No user found"
 msgstr "검색 결과가 없습니다"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -397,11 +411,11 @@ msgstr "팟캐스트 디렉터리"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"f%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"f%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -461,8 +475,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "팟캐스트"
 
@@ -487,14 +501,14 @@ msgid "Podcasts with License Information"
 msgstr "호스트 정보"
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr "팟캐스트"
 
@@ -541,7 +555,7 @@ msgid "OK"
 msgstr "확인"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr "빠진 팟캐스트"
 
@@ -574,7 +588,7 @@ msgstr "빠진 팟캐스트"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr "팟캐스트 목록"
 
@@ -590,6 +604,7 @@ msgstr "사용자"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "다운로드"
 
@@ -608,8 +623,8 @@ msgstr "좋아하는 주제의 팟캐스트 목록 만들기"
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "검색"
 
@@ -641,20 +656,20 @@ msgstr "순위"
 msgid "Client Access"
 msgstr "클라이언트 접근"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr "팟캐스트 %d개 추가함"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "기록"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -675,7 +690,7 @@ msgid "Action"
 msgstr "동작"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "장치"
 
@@ -685,7 +700,7 @@ msgstr "추가"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr "구독 기록"
@@ -720,7 +735,7 @@ msgstr "지금"
 msgid "Earlier"
 msgstr "더 예전"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -800,16 +815,16 @@ msgstr "팟캐스트 목록 by %(username)s"
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s 사용자는 아직 팟캐스트를 하나도 만들지 않았습니다."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr "제목을 지정해야 합니다."
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr "\"{title}\"은(는) 올바른 제목이 아닙니다."
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr "평가해 주셔서 감사합니다!"
 
@@ -853,24 +868,24 @@ msgstr "즐겨 듣기"
 msgid "Episode History"
 msgstr "에피소드"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "이름 없는 팟캐스트"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr "by"
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr "피드"
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr "구독자"
@@ -943,9 +958,9 @@ msgstr "'YOUR_ADRESS' 필드를 여러분 팟캐스트 피드 주소로 바꾸�
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "광고"
 
@@ -1014,21 +1029,6 @@ msgstr ""
 "캐스트를 적극적으로 찾는 사람들입니다. 하지만 광고 기간 중에 일정 수의 방문자"
 "를 보장하지는 않습니다."
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "광고 시작하기"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"%(sitename)s 사이트에 광고를 하고 싶거나 문의 사항이 있으면 <a href=\"mailto:"
-"stefan@gpodder.net\">stefan@gpodder.net</a> 주소로 연락하십시오. 광고비는 "
-"PayPal thp@perli.net으로 보냅니다."
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "이름 없는 에피소드"
@@ -1055,7 +1055,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr "저장"
@@ -1074,7 +1074,7 @@ msgstr "팟캐스트 페이지로 돌아가기"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "에피소드"
 
@@ -1168,8 +1168,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 "<a href=\"%(advertise-url)s\">광고 페이지</a>에서 자세히 볼 수 있습니다."
 
@@ -1189,8 +1189,8 @@ msgstr ""
 #| "podcast listed on %(sitename)s, feel free to apply by sending a mail "
 #| "with\n"
 #| "  <ul>\n"
-#| "   <li>your username on %(sitename)s (<a href=\"%(register-url)s"
-#| "\">register if you don't have one</a>)</li>\n"
+#| "   <li>your username on %(sitename)s (<a "
+#| "href=\"%(register-url)s\">register if you don't have one</a>)</li>\n"
 #| "   <li>the name and URL of the podcast you are publishing</li>\n"
 #| "   <li>an email address that is visible somewhere on the podcast's "
 #| "website (to legitimate you)\n"
@@ -1209,8 +1209,9 @@ msgid ""
 "  to <a href=\"mailto:support@gpodder.net\">support@gpodder.net</a>."
 msgstr ""
 "제작자 페이지는 현재 베타 버전입니다. %(sitename)s에 들어 있는 팟캐스트의 제"
-"작자라면 다음과 같은 내용의 메일을 <a href=\"mailto:stefan@gpodder.net"
-"\">stefan@gpodder.net</a> 주소로 보내 지원해 주십시오.\n"
+"작자라면 다음과 같은 내용의 메일을 <a "
+"href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> 주소로 보내 지원해 "
+"주십시오.\n"
 "  <ul>\n"
 "   <li>%(sitename)s의 사용자 이름 (<a href=\"%(register-url)s\">아직 없으면 "
 "등록</a>)</li>\n"
@@ -1284,8 +1285,8 @@ msgstr ""
 msgid "Update now"
 msgstr "지금 업데이트"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -1344,8 +1345,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1364,23 +1365,23 @@ msgstr "링크"
 msgid "Show Group Stats"
 msgstr "그룹 통계 표시"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 "업데이트가 예정되어 있습니다. 결과가 나오려면 시간이 걸릴 수도 있습니다."
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr "데이터 업데이트됨"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr "제작자 토큰이 업데이트되었습니다"
 
 # slug - RSS permlink의 유니크한 부분을 말한다
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr "{episode}의 슬러그 {slug} 제거함"
@@ -1453,8 +1454,8 @@ msgstr "공유"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "구독"
 
@@ -1469,7 +1470,7 @@ msgid "User Page"
 msgstr "사용자 페이지"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "설정"
 
@@ -1588,9 +1589,9 @@ msgstr "에피소드 %(episode_count)s개"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 "아직 구독이 없습니다. <a href=\"%(devices)s\">팟캐스트 클라이언트</a>와 <a "
 "href=\"%(directory)s\">재미있는 팟캐스트 찾기</a>를 설정하십시오."
@@ -1601,22 +1602,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr "OPML 다운로드"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "%(username)s의 팟캐스트 구독, (%(site)s)"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr "최근에 %(username)s의 팟캐스트 구독 (%(site)s) 변경 사항"
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "%(username)s %(podcast)s에 구독 (%(site)s)"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "%(username)s %(podcast)s에서 구독 해제 (%(site)s)"
@@ -1634,27 +1635,27 @@ msgstr "관심 없음"
 msgid "No Suggestions Yet"
 msgstr "아직 추천 없음"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "데스크톱"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "노트북"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "휴대전화"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "서버"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "기타"
 
@@ -1693,9 +1694,9 @@ msgid "You are already registered."
 msgstr "이미 등록했습니다."
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "등록"
 
@@ -1779,53 +1780,65 @@ msgstr "구독을 업로드할 수 없습니다: {err}"
 msgid "Your subscription will be updated in a moment."
 msgstr "새로 구독하면 기본값으로 비공개입니다."
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 #, fuzzy
 #| msgid "Your account already has been activated. Go ahead and log in."
 msgid "Your user has been activated. You can log in now."
 msgstr "계정을 이미 활성화했습니다. 계속 사용하시려면 로그인하십시오."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "사용자가 없습니다."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your account has been deleted"
+msgid "Your data has been archived."
+msgstr "계정이 삭제되었습니다"
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "계정을 이미 활성화했습니다. 계속 사용하시려면 로그인하십시오."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr "앗! 뭔가가 잘못됐습니다. 입력한 데이터가 맞는지 한 번 더 확인하십시오."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr "계정의 연결이 끊겼습니다"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr "사용자 이름이 없습니다"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr "비밀번호가 없습니다"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "사용자 이름 또는 비밀번호가 틀렸습니다."
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 #, fuzzy
 #| msgid "Please activate your account first."
 msgid ""
@@ -1833,78 +1846,57 @@ msgid ""
 "email"
 msgstr "먼저 계정을 활성화하십시오."
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr "로그인 실패."
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-"계정이 {google} 계정과 연결되었습니다. 변경하려면 설정 페이지를 여십시오."
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr "%s Google 계정과 연결된 계정이 없습니다. 연결하려면 로그인하십시오."
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "전자메일 주소"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "현재 비밀번호"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "새 비밀번호"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "비밀번호 확인"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr "짤막한 자기 소개"
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "이름"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "종류"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "장치 ID"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 #, fuzzy
 #| msgid "Device"
 msgid "ID on device"
 msgstr "장치"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "이 구독을 다른 사용자와 공유 (공개)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "장치를 선택하지 않았습니다"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "사용자 이름을 입력하십시오"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "(또는 등록할 때 사용한 메일 주소)"
 
@@ -1946,110 +1938,97 @@ msgstr "%(gmail)s 계정에 연결됨"
 msgid "Disconnect"
 msgstr "연결 해제"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr "연결"
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "계정"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "로그인"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr "Google로 로그인"
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "팟캐스트 찾기"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "디렉터리"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr "지원"
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr "문서"
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr "메일링&nbsp;리스트"
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr "문의"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr "후원&nbsp;안내"
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr "기부"
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr "팔로우"
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr "블로그"
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr "블로그&nbsp;(RSS)"
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr "개발"
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr "API"
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "라이브러리"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr "클라이언트"
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr "발행"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr "접근하기"
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr "여기로&nbsp;링크"
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr "기여"
 
@@ -2076,27 +2055,25 @@ msgstr "작업"
 #| "If you want to contribute to gpodder.net by writing code, check out the "
 #| "<a href=\"/developer/\">Development</a> page. We also appreciate "
 #| "contributions of non-coding work, such as web and interface design, "
-#| "server operations, testing, etc. If you are interested, join the <a href="
-#| "\"http://wiki.gpodder.org/wiki/Mailing_List\">mailing list</a> or the IRC "
-#| "channel #gpodder on chat.freenode.net."
+#| "server operations, testing, etc. If you are interested, join the <a "
+#| "href=\"http://wiki.gpodder.org/wiki/Mailing_List\">mailing list</a> or "
+#| "the IRC channel #gpodder on chat.freenode.net."
 msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 "코드 작성으로 gpodder.net에 기여하시려면, <a href<a href=\"/developer/\">개발"
 "</a> 페이지를 보십시오. 웹, 인터페이스 디자인, 서버 작업, 테스트 같은 코딩이 "
-"아닌 작업도 환영합니다. 관심이 있으시면 <a href=\"https://gpoddernet."
-"readthedocs.io/en/wiki/Mailing_List\">메일링 리스트</a> 또는 chat.freenode."
-"net의 IRC 채널 #gpodder에 참여해 보십시오."
+"아닌 작업도 환영합니다. 관심이 있으시면 <a href=\"https://"
+"gpoddernet.readthedocs.io/en/wiki/Mailing_List\">메일링 리스트</a> 또는 "
+"chat.freenode.net의 IRC 채널 #gpodder에 참여해 보십시오."
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2127,7 +2104,7 @@ msgstr "예"
 msgid "No"
 msgstr "아니요"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "개요"
 
@@ -2143,25 +2120,29 @@ msgstr "새 에피소드"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
-"%(site)s에 잘 오셨습니다! 처음 오셨으면, <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">팟캐스트 클라이언트</a>를 설정하"
-"시고 간으한 여러 <em>둘러보기</em> 상자를 확인해 보세요."
+"%(site)s에 잘 오셨습니다! 처음 오셨으면, <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">팟캐스트 클라이언트</"
+"a>를 설정하시고 간으한 여러 <em>둘러보기</em> 상자를 확인해 보세요."
 
 #: mygpo/web/templates/dashboard.html:44
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
+#| "ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-"
+#| "list.html\">mailing list</a> or <a href=\"https://github.com/gpodder/"
+#| "mygpo/issues\">forum</a>."
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
-"문제가 있으면<a href=\"%(help)s\">문서</a>를 보시거나, <a href=\"http://wiki."
-"gpodder.org/wiki/Mailing_List\">메일링 리스트</a> 또는 <a href=\"https://"
-"getsatisfaction.com/gpoddernet\">포럼</a>에 질문하십시오."
+"문제가 있으면<a href=\"%(help)s\">문서</a>를 보시거나, <a href=\"http://"
+"wiki.gpodder.org/wiki/Mailing_List\">메일링 리스트</a> 또는 <a "
+"href=\"https://getsatisfaction.com/gpoddernet\">포럼</a>에 질문하십시오."
 
 #: mygpo/web/templates/dashboard.html:81
 #, python-format
@@ -2251,7 +2232,7 @@ msgid "Thanks"
 msgstr "감사합니다"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr "개발"
 
@@ -2264,8 +2245,9 @@ msgstr "웹서비스"
 #| msgid ""
 #| "The sourcecode of the webservice gpodder.net is released as open source "
 #| "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted "
-#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://bugs.gpodder."
-#| "org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
+#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://"
+#| "bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</"
+#| "a>."
 msgid ""
 "The sourcecode of the webservice gpodder.net is released as open source "
 "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted at "
@@ -2274,8 +2256,8 @@ msgid ""
 msgstr ""
 "gpodder.net 웹서비스의 소스 코드는 AGPL 버전3에 따라 오픈소스로 공개되고 <a "
 "href=\"https://github.com/gpodder.net/mygpo\">GitHub에서 호스팅합니다</a>. 문"
-"제점은 <a href=\"https://bugs.gpodder.org/enter_bug.cgi?product=gpodder.net"
-"\">gPodder Bugtracker</a>에서 전달할 수 있습니다."
+"제점은 <a href=\"https://bugs.gpodder.org/enter_bug.cgi?"
+"product=gpodder.net\">gPodder Bugtracker</a>에서 전달할 수 있습니다."
 
 #: mygpo/web/templates/developer.html:21
 msgid "Integrating Clients"
@@ -2287,9 +2269,9 @@ msgid ""
 "want to use one of the existing <a href=\"https://gpoddernet.readthedocs.io/"
 "en/latest/dev/libraries.html\">client libraries</a>."
 msgstr ""
-"gpodder.net을 팟캐스트 클라이언트에 연동하려면, <a href=\"http://wiki."
-"gpodder.org/wiki/Web_Services/Libraries\">클라이언트 라이브러리</a> 중 하나"
-"를 사용해 보십시오."
+"gpodder.net을 팟캐스트 클라이언트에 연동하려면, <a href=\"http://"
+"wiki.gpodder.org/wiki/Web_Services/Libraries\">클라이언트 라이브러리</a> 중 "
+"하나를 사용해 보십시오."
 
 #: mygpo/web/templates/developer.html:23
 msgid ""
@@ -2388,9 +2370,9 @@ msgstr "동기화되지 않음"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 "아직 장치가 하나도 없습니다. <a href=\"https://gpoddernet.readthedocs.io/en/"
 "Web_Services/Clients\">클라이언트</a> 페이지로 가서 클라이언트 애플리케이션 "
@@ -2409,7 +2391,7 @@ msgid "Delete Permanently"
 msgstr "영구히 삭제"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "즐겨 듣는 에피소드"
 
@@ -2435,18 +2417,18 @@ msgstr ""
 "다렸다 다시 시도해 보십시오"
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "내 태그"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"아직 어떤 팟캐스트에도 태그를 붙이지 않았습니다. <a href="
-"\"%(subscriptions-url)s\">구독</a>으로 가서 태그를 붙이십시오."
+"아직 어떤 팟캐스트에도 태그를 붙이지 않았습니다. <a "
+"href=\"%(subscriptions-url)s\">구독</a>으로 가서 태그를 붙이십시오."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2459,8 +2441,8 @@ msgstr "암호를 초기화했습니다"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 "새 암호가 들어 있는 메일을 받았을 것입니다. 지금 <a href=\"%(login-url)s\">로"
 "그인</a>하십시오."
@@ -2524,7 +2506,7 @@ msgstr "비공개 구독"
 msgid "Make Public"
 msgstr "공개로 만들기"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr "개인 정보 정책"
 
@@ -2570,6 +2552,17 @@ msgid ""
 msgstr ""
 "피드에서 가져온 정보를 바탕으로 이름을 표시하고, 가져오는데 시간이 걸릴 수 있"
 "기 때문에, 이런 작업이 끝나기 전까지는 이 팟캐스트는 이런 식으로 불립니다."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Reactivate"
+msgid "Archived User"
+msgstr "다시 활성화"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2618,8 +2611,8 @@ msgid ""
 "Add <tt>&amp;symbian=true#.opml</tt> to the OPML URL to get an OPML file for "
 "Nokia Podcasting on Symbian devices."
 msgstr ""
-"심비안 장치의 노키아 팟캐스트용 OPML 파일을 받으려면 OPML URL에 <tt>&amp;"
-"symbian=true#.opml</tt> 이라고 추가하십시오."
+"심비안 장치의 노키아 팟캐스트용 OPML 파일을 받으려면 OPML URL에 "
+"<tt>&amp;symbian=true#.opml</tt> 이라고 추가하십시오."
 
 #: mygpo/web/templates/user_subscriptions_denied.html:20
 #, python-format
@@ -2722,47 +2715,51 @@ msgstr "이 에피소드를 삭제했습니다"
 msgid "Unknown Episode"
 msgstr "알 수 없는 에피소드"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "홈"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "도움말"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "사용자 구독"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "제안"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr "순위"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "장치"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr "커뮤니티"
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr "내 사용자 페이지"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "개인 정보"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "gpodder.net에 링크"
 
@@ -2777,51 +2774,89 @@ msgstr "{h}시간 {m}분 {s}초"
 msgid "{m}m {s}s"
 msgstr "{h}시간 {m}분 {s}초"
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "다른 사이트"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "광고 시작하기"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "%(sitename)s 사이트에 광고를 하고 싶거나 문의 사항이 있으면 <a "
+#~ "href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> 주소로 연락하십"
+#~ "시오. 광고비는 PayPal thp@perli.net으로 보냅니다."
+
+#~ msgid "Login failed."
+#~ msgstr "로그인 실패."
+
+#, python-brace-format
+#~ msgid ""
+#~ "Your account has been connected with {google}. Open Settings to change "
+#~ "this."
+#~ msgstr ""
+#~ "계정이 {google} 계정과 연결되었습니다. 변경하려면 설정 페이지를 여십시오."
+
+#, python-format
+#~ msgid ""
+#~ "No account connected with your Google account %s. Please log in to "
+#~ "connect."
+#~ msgstr "%s Google 계정과 연결된 계정이 없습니다. 연결하려면 로그인하십시오."
+
+#~ msgid "Connect"
+#~ msgstr "연결"
+
+#~ msgid "Login with Google"
+#~ msgstr "Google로 로그인"
+
+#~ msgid "Mailing&nbsp;List"
+#~ msgstr "메일링&nbsp;리스트"
 
 #, fuzzy
 #~| msgid ""
 #~| "If you want to support gpodder.net financially, you can donate via "
 #~| "PayPal to stefan@skoegl.net. You can also send a book via Amazon (<a "
-#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href="
-#~| "\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www."
-#~| "amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~| "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~| "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 #~ msgid ""
 #~ "If you want to support gpodder.net financially, you can donate via <a "
 #~ "href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>. You can also "
-#~ "send a book via Amazon (<a href=\"http://www.amazon.de/"
-#~ "wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R"
-#~ "\">US</a> or <a href=\"http://www.amazon.co.uk/registry/"
-#~ "wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "send a book via Amazon (<a href=\"http://www.amazon.de/wishlist/"
+#~ "24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</"
+#~ "a> or <a href=\"http://www.amazon.co.uk/registry/wishlist/"
+#~ "24JRVURXUKO6F\">UK</a>)."
 #~ msgstr ""
 #~ "금전적으로 gpodder.net을 지원하시려면, 페이팔로 stefan@skoegl.net에 기부하"
-#~ "실 수 있습니다. 또 아마존 (<a href=\"http://www.amazon.de/"
-#~ "wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R"
-#~ "\">US</a>, <a href=\"http://www.amazon.co.uk/registry/"
-#~ "wishlist/24JRVURXUKO6F\">UK</a>)를 통해 책을 보내 주실 수도 있습니다."
+#~ "실 수 있습니다. 또 아마존 (<a href=\"http://www.amazon.de/wishlist/"
+#~ "24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</"
+#~ "a>, <a href=\"http://www.amazon.co.uk/registry/wishlist/"
+#~ "24JRVURXUKO6F\">UK</a>)를 통해 책을 보내 주실 수도 있습니다."
 
 #, fuzzy
 #~| msgid "Last update: "
@@ -2938,8 +2973,8 @@ msgstr "다른 사이트"
 #~ msgstr "자기 컨텐츠의 사용자 이름"
 
 #~ msgid ""
-#~ "Connected with <a href=\"https://flattr.com/profile/%(flattrname)s\">"
-#~ "%(flattrname)s</a>"
+#~ "Connected with <a href=\"https://flattr.com/profile/%(flattrname)s\">%"
+#~ "(flattrname)s</a>"
 #~ msgstr ""
 #~ "<a href=\"https://flattr.com/profile/%(flattrname)s\">%(flattrname)s</a> "
 #~ "flattr에 연결됨"
@@ -3080,8 +3115,8 @@ msgstr "다른 사이트"
 #~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> with the <a "
 #~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
 #~ msgstr ""
-#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> (<a href="
-#~ "\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>와 같이)"
+#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> (<a "
+#~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>와 같이)"
 
 #~ msgid "Nokia Podcasting on Symbian devices"
 #~ msgstr "심비안 장치의 노키아 팟캐스트"
@@ -3116,8 +3151,8 @@ msgstr "다른 사이트"
 #~ "시오.</strong>"
 
 #~ msgid ""
-#~ "A list of your devices can be found on the <a href=\"%(devices-url)s"
-#~ "\">devices page</a>."
+#~ "A list of your devices can be found on the <a href=\"%(devices-"
+#~ "url)s\">devices page</a>."
 #~ msgstr "장치 목록은 <a href=\"%(devices-url)s\">장치 페이지</a>에 있습니다."
 
 #~ msgid "Synchronizing Devices"
@@ -3153,21 +3188,21 @@ msgstr "다른 사이트"
 #~ msgstr "에피소드 상태는 (재생, 다운로드 등) 모든 장치에 대해 동기화됩니다."
 
 #~ msgid ""
-#~ "By default we include information about your subscriptions in our <a href="
-#~ "\"%(toplist-url)s\">toplist</a> and <a href=\"%(suggestions-url)s"
-#~ "\">podcast suggestions</a>. <strong>We will never associate your username "
-#~ "and/or email address with your subscriptions on public pages.</strong> "
-#~ "You can even opt-out from our anonymized statistics at the <a href="
-#~ "\"%(privacy-url)s\">privacy page</a>. If you mark some podcasts as "
+#~ "By default we include information about your subscriptions in our <a "
+#~ "href=\"%(toplist-url)s\">toplist</a> and <a href=\"%(suggestions-"
+#~ "url)s\">podcast suggestions</a>. <strong>We will never associate your "
+#~ "username and/or email address with your subscriptions on public pages.</"
+#~ "strong> You can even opt-out from our anonymized statistics at the <a "
+#~ "href=\"%(privacy-url)s\">privacy page</a>. If you mark some podcasts as "
 #~ "private, they will also not show up in your sharable subscription list."
 #~ msgstr ""
-#~ "기본값으로 <a href=\"%(toplist-url)s\">순위</a> 및 <a href="
-#~ "\"%(suggestions-url)s\">팟캐스트 추천</a>에 여러분의 구독을 포함하고 있습"
-#~ "니다. <strong>저희는 절대로 구독한 여러분의 사용자 이름이나 메일 주소를 공"
-#~ "개 페이지에 연결하지 않습니다.</strong> 원하시면 <a href=\"%(privacy-url)s"
-#~ "\">개인정보 페이지</a>에서 저희의 익명화된 통계를 거부하실 수도 있습니다. "
-#~ "또 비공개로 표시한 팟캐스트의 경우에도, 공유 가능 구독 목록에 나타나지 않"
-#~ "습니다."
+#~ "기본값으로 <a href=\"%(toplist-url)s\">순위</a> 및 <a href=\"%"
+#~ "(suggestions-url)s\">팟캐스트 추천</a>에 여러분의 구독을 포함하고 있습니"
+#~ "다. <strong>저희는 절대로 구독한 여러분의 사용자 이름이나 메일 주소를 공"
+#~ "개 페이지에 연결하지 않습니다.</strong> 원하시면 <a href=\"%(privacy-"
+#~ "url)s\">개인정보 페이지</a>에서 저희의 익명화된 통계를 거부하실 수도 있습"
+#~ "니다. 또 비공개로 표시한 팟캐스트의 경우에도, 공유 가능 구독 목록에 나타나"
+#~ "지 않습니다."
 
 #~ msgid "Sharing your Subscriptions"
 #~ msgstr "내 구독 공유하기"
@@ -3178,9 +3213,9 @@ msgstr "다른 사이트"
 #~ "can either share your private URL with your friends or make it public and "
 #~ "share your subscriptions with the whole world."
 #~ msgstr ""
-#~ "내가 어떤 팟캐스트를 듣고 있는지 다른 사람에게 알리려면, <a href="
-#~ "\"%(share-url)s\">공유 페이지</a>로 가십시오. 비공개 URL을 친구들과 공유"
-#~ "할 수도 있고, 공개로 만들어서 전세계와 공유할 수도 있습니다."
+#~ "내가 어떤 팟캐스트를 듣고 있는지 다른 사람에게 알리려면, <a href=\"%"
+#~ "(share-url)s\">공유 페이지</a>로 가십시오. 비공개 URL을 친구들과 공유할 수"
+#~ "도 있고, 공개로 만들어서 전세계와 공유할 수도 있습니다."
 
 #~ msgid "Subscribe to this podcast"
 #~ msgstr "이 팟캐스트에 구독"
@@ -3195,9 +3230,9 @@ msgstr "다른 사이트"
 #~ msgstr "공개로 바꾸기"
 
 #~ msgid ""
-#~ "Browse the <a href=\"%(toplist-url)s\">toplist</a> and your <a href="
-#~ "\"%(suggestions-url)s\">personal suggestions</a>, <a href=\"%(search-url)s"
-#~ "\">search</a> or paste the URL of the podcast's feed here"
+#~ "Browse the <a href=\"%(toplist-url)s\">toplist</a> and your <a href=\"%"
+#~ "(suggestions-url)s\">personal suggestions</a>, <a href=\"%(search-"
+#~ "url)s\">search</a> or paste the URL of the podcast's feed here"
 #~ msgstr ""
 #~ "<a href=\"%(toplist-url)s\">순위</a> 및 <a href=\"%(suggestions-url)s\">개"
 #~ "인 추천</a>을 찾아보거나, <a href=\"%(search-url)s\">검색</a>하거나, 팟캐"
@@ -3219,11 +3254,11 @@ msgstr "다른 사이트"
 #~ msgstr "%s의 계정에 대해 비밀번호 초기화"
 
 #~ msgid ""
-#~ "Here is your new password for your account %(username)s on %(site)s: "
-#~ "%(password)s"
+#~ "Here is your new password for your account %(username)s on %(site)s: %"
+#~ "(password)s"
 #~ msgstr ""
-#~ "다음은 %(site)s 사이트 %(username)s 사용자의 새 비밀번호입니다: "
-#~ "%(password)s"
+#~ "다음은 %(site)s 사이트 %(username)s 사용자의 새 비밀번호입니다: %"
+#~ "(password)s"
 
 #~ msgid "Invalid Username entered"
 #~ msgstr "잘못된 사용자 이름을 입력했습니다"

--- a/mygpo/locale/nb/LC_MESSAGES/django.po
+++ b/mygpo/locale/nb/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2010-02-28 18:33+0100\n"
 "Last-Translator: Jim Nygård <jim@nygard.priv.no>\n"
 "Language-Team: gpodder <>\n"
@@ -26,7 +26,7 @@ msgstr ""
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 #, fuzzy
 msgid "Username"
 msgstr "Velg et brukernavn"
@@ -158,7 +158,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr ""
 
@@ -197,7 +197,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr "Podkast/episode"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -289,26 +293,36 @@ msgstr ""
 msgid "User-Agent"
 msgstr ""
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr ""
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 #, fuzzy
 msgid "No user found"
 msgstr "Ikke funnet"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -391,8 +405,8 @@ msgstr "For podkastredaktører"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
 
 #: mygpo/directory/templates/directory.html:46
@@ -456,8 +470,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podkast"
 
@@ -481,14 +495,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 #, fuzzy
 msgid "Podcasts"
 msgstr "Podkast"
@@ -536,7 +550,7 @@ msgid "OK"
 msgstr "OK"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 #, fuzzy
 msgid "Missing Podcast"
 msgstr "Podkastforslag"
@@ -570,7 +584,7 @@ msgstr "Podkastforslag"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 #, fuzzy
 msgid "Podcast Lists"
 msgstr "Podkast toppliste"
@@ -589,6 +603,7 @@ msgstr "Velg et brukernavn"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 #, fuzzy
 msgid "Download"
 msgstr "lastet ned"
@@ -608,8 +623,8 @@ msgstr ""
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Søk"
 
@@ -643,20 +658,20 @@ msgstr "Toppliste"
 msgid "Client Access"
 msgstr ""
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, fuzzy, python-format
 msgid "%d podcasts added"
 msgstr "Podkaster"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Historikk"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 #, fuzzy
@@ -680,7 +695,7 @@ msgid "Action"
 msgstr "Handling"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Enhet"
 
@@ -690,7 +705,7 @@ msgstr ""
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 #, fuzzy
 msgid "Subscription History"
@@ -725,7 +740,7 @@ msgstr ""
 msgid "Earlier"
 msgstr ""
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -808,16 +823,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s har ingen abonnementer ennå."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -861,24 +876,24 @@ msgstr ""
 msgid "Episode History"
 msgstr "Din episodehistorikk"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Podkast uten navn"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 #, fuzzy
 msgid "subscribers"
@@ -950,9 +965,9 @@ msgstr "Bytt ut teksten 'YOUR_ADRESS' med adressen til din podkast."
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr ""
 
@@ -1011,18 +1026,6 @@ msgid ""
 "advertisement period."
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr ""
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "Episoden uten navn"
@@ -1045,7 +1048,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1065,7 +1068,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Episoder"
 
@@ -1154,8 +1157,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/info.html:27
@@ -1237,8 +1240,8 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1293,8 +1296,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1313,23 +1316,23 @@ msgstr ""
 msgid "Show Group Stats"
 msgstr ""
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 #, fuzzy
 msgid "Data updated"
 msgstr "Enhetsliste"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 #, fuzzy
 msgid "Publisher token updated"
 msgstr "Abonner på nye podkaster"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1407,8 +1410,8 @@ msgstr "Hvor"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Abonnementer"
 
@@ -1425,7 +1428,7 @@ msgid "User Page"
 msgstr "Velg et brukernavn"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Innstillinger"
 
@@ -1548,9 +1551,9 @@ msgstr "Del dine abonnement"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1560,22 +1563,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr "lastet ned"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, fuzzy, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "%(username)s sine Abonnement"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, fuzzy, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "Abonner på %(podcasttitle)s"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, fuzzy, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "Abonner på %(podcasttitle)s"
@@ -1594,27 +1597,27 @@ msgstr ""
 msgid "No Suggestions Yet"
 msgstr "Forslag"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Desktop"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Laptop"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Mobiltelefon"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Tjener"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Annen"
 
@@ -1654,9 +1657,9 @@ msgid "You are already registered."
 msgstr ""
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Registrer"
 
@@ -1745,140 +1748,131 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 #, fuzzy
 #| msgid "Your account already has been activated. Go ahead and log in."
 msgid "Your user has been activated. You can log in now."
 msgstr "Din konto er allerede aktivert. Det er bare å logge inn."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "Brukeren finnes ikke."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your settings have been saved."
+msgid "Your data has been archived."
+msgstr "Dine innstillinger er lagret."
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "Din konto er allerede aktivert. Det er bare å logge inn."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 #, fuzzy
 msgid "Your account has been disconnected"
 msgstr "Din konto er slettet"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 #, fuzzy
 msgid "Username missing"
 msgstr "Velg et brukernavn"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 #, fuzzy
 msgid "Password missing"
 msgstr "Passord tilbakestilt"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 #, fuzzy
 msgid "Wrong username or password."
 msgstr "Ukjent bruker eller feil passord"
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 #, fuzzy
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr "Du må aktivere brukeren først."
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-#, fuzzy
-msgid "Login failed."
-msgstr "Logg inn"
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 #, fuzzy
 msgid "E-Mail address"
 msgstr "Din e-postadresse"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 #, fuzzy
 msgid "Current password"
 msgstr "Ditt nåværende passord"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 #, fuzzy
 msgid "New password"
 msgstr "Ditt nye passord"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 #, fuzzy
 msgid "Confirm password"
 msgstr "Ditt nye passord"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Navn"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Type"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 #, fuzzy
 msgid "Device ID"
 msgstr "Enhet"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 #, fuzzy
 #| msgid "Device"
 msgid "ID on device"
 msgstr "Enhet"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr ""
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Ingen enhet valgt"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Angi ditt brukernavn"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "eller e-postadressen du brukte ved registrering"
 
@@ -1922,113 +1916,100 @@ msgstr ""
 msgid "Disconnect"
 msgstr "Oppdag"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 #, fuzzy
 msgid "Account"
 msgstr "Slett konto"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Logg inn"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Oppdag"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 #, fuzzy
 msgid "Directory"
 msgstr "Historikk"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 #, fuzzy
 msgid "Questions"
 msgstr "Forslag"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr ""
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr ""
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -2052,15 +2033,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2089,7 +2068,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr ""
 
@@ -2106,18 +2085,17 @@ msgstr "Siste episode"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2215,7 +2193,7 @@ msgid "Thanks"
 msgstr "Takk"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2345,9 +2323,9 @@ msgstr "Ikke synkronisert"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2365,7 +2343,7 @@ msgid "Delete Permanently"
 msgstr "Slett konto"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 #, fuzzy
 msgid "Favorite Episodes"
 msgstr "Siste episode"
@@ -2392,15 +2370,15 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
 
 #: mygpo/web/templates/password_reset.html:4
@@ -2414,8 +2392,8 @@ msgstr "Passordet er tilbakestilt"
 #: mygpo/web/templates/password_reset.html:13
 #, fuzzy, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 "Du skal nå ha motatt en e-post med ditt nye passord. Vennligst <a href=\"/"
 "login\">logg inn</a> nå."
@@ -2477,7 +2455,7 @@ msgstr "Abonnementer"
 msgid "Make Public"
 msgstr ""
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 #, fuzzy
 msgid "Privacy Policy"
 msgstr "Personvern"
@@ -2526,6 +2504,15 @@ msgid ""
 msgstr ""
 "Fordi vi viser navnene etter å ha hentet informasjonen i strømmen, dette kan "
 "ta litt tid. I mellomtiden vil podkasten vises uten navn."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+msgid "Archived User"
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2689,50 +2676,54 @@ msgstr "Denne episoden er slettet"
 msgid "Unknown Episode"
 msgstr "Episoden uten navn"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Hjem"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 #, fuzzy
 msgid "User subscriptions"
 msgstr "Dine Abonnement"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Forslag"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 #, fuzzy
 msgid "Toplists"
 msgstr "Toppliste"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Enheter"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 #, fuzzy
 msgid "My Userpage"
 msgstr "Velg et brukernavn"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Personvern"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr ""
 
@@ -2746,30 +2737,34 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Login failed."
+#~ msgstr "Logg inn"
 
 #, fuzzy
 #~ msgid "Last update:"
@@ -2896,9 +2891,9 @@ msgstr ""
 
 #, fuzzy
 #~ msgid ""
-#~ "Browse the <a href=\"%(toplist-url)s\">toplist</a> and your <a href="
-#~ "\"%(suggestions-url)s\">personal suggestions</a>, <a href=\"%(search-url)s"
-#~ "\">search</a> or paste the URL of the podcast's feed here"
+#~ "Browse the <a href=\"%(toplist-url)s\">toplist</a> and your <a href=\"%"
+#~ "(suggestions-url)s\">personal suggestions</a>, <a href=\"%(search-"
+#~ "url)s\">search</a> or paste the URL of the podcast's feed here"
 #~ msgstr ""
 #~ "Se igjennom <a href=\"/toplist/\">topplisten</a> og dine <a href=\"/"
 #~ "suggestions/\">personlige anbefalinger</a>, <a href=\"/search/\">søk</a> "
@@ -2916,8 +2911,8 @@ msgstr ""
 
 #, fuzzy
 #~ msgid ""
-#~ "Here is your new password for your account %(username)s on %(site)s: "
-#~ "%(password)s"
+#~ "Here is your new password for your account %(username)s on %(site)s: %"
+#~ "(password)s"
 #~ msgstr "Dette er ditt nye passord for kontoen på %(site)s: %(password)s"
 
 #~ msgid "Invalid Username entered"
@@ -2944,8 +2939,8 @@ msgstr ""
 
 #, fuzzy
 #~ msgid ""
-#~ "If you're new here, you should start by reading our <a href=\"%(help-url)s"
-#~ "\">introduction</a>."
+#~ "If you're new here, you should start by reading our <a href=\"%(help-"
+#~ "url)s\">introduction</a>."
 #~ msgstr ""
 #~ "Hvis du er ny her bør du begynne med å lese <a href=\"/online-help/"
 #~ "\">Introduksjon</a>."
@@ -2981,9 +2976,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Det oppstod en feil under med forespørselen, en e-post med "
 #~ "feilbeskrivelse er sendt til utviklerene."
-
-#~ msgid "Your settings have been saved."
-#~ msgstr "Dine innstillinger er lagret."
 
 #, fuzzy
 #~ msgid "Update account settings"

--- a/mygpo/locale/nl/LC_MESSAGES/django.po
+++ b/mygpo/locale/nl/LC_MESSAGES/django.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>, 2018\n"
-"Language-Team: Dutch (Netherlands) (https://www.transifex.com/yaron/"
-"teams/87581/nl_NL/)\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/yaron/teams/"
+"87581/nl_NL/)\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -28,7 +28,7 @@ msgstr "Gebruiker activeren"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Gebruikersnaam"
 
@@ -154,7 +154,7 @@ msgstr "Ingeplande Celery-taken"
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr "Uitgeversmachtigingen"
 
@@ -191,7 +191,11 @@ msgstr "Als je vragen hebt, ga dan naar %(url)s"
 msgid "Merge Podcasts and Episodes"
 msgstr "Podcasts en afleveringen samenvoegen"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -286,25 +290,37 @@ msgstr "Verversen"
 msgid "User-Agent"
 msgstr "Gebruikersagent"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "Geen podcast met de URL {url}"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr "Geef een gebruikersnaam of e-mailadres op"
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr "Geen gebruiker gevonden"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr "Gebruiker {username} ({email}) is geactiveerd"
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} is already activated"
+msgstr "Gebruiker {username} ({email}) is geactiveerd"
+
+#: mygpo/administration/views.py:383
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} data has been archived."
+msgstr "Gebruiker {username} ({email}) is geactiveerd"
+
+#: mygpo/administration/views.py:389
 #, fuzzy, python-brace-format
 #| msgid "User {username} ({email}) activated"
 msgid "Email for {username} ({email}) resent"
@@ -387,11 +403,11 @@ msgstr "Podcastmap"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"%(listtitle)s <span class=\"by-user\">door <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">door <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -450,8 +466,8 @@ msgstr "Licentie tonen"
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podcast"
 
@@ -474,14 +490,14 @@ msgid "Podcasts with License Information"
 msgstr "Podcasts met licentie-informatie"
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr "Licentie"
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr "Podcasts"
 
@@ -528,7 +544,7 @@ msgid "OK"
 msgstr "Oké"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr "Ontbrekende podcast"
 
@@ -561,7 +577,7 @@ msgstr "Gesponsorde podcast"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr "Podcastlijsten"
 
@@ -577,6 +593,7 @@ msgstr "Gebruiker"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "Downloaden"
 
@@ -595,8 +612,8 @@ msgstr "Creëer een lijst met podcasts over een onderwerp dat je interesseert"
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Zoeken"
 
@@ -628,20 +645,20 @@ msgstr "Toplijst"
 msgid "Client Access"
 msgstr "Client-toegang"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr "%d podcasts toegevoegd"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Geschiedenis"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -662,7 +679,7 @@ msgid "Action"
 msgstr "Actie"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Apparaat"
 
@@ -672,7 +689,7 @@ msgstr "Toevoegen"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr "Abonnementsgeschiedenis"
@@ -706,7 +723,7 @@ msgstr "Nu"
 msgid "Earlier"
 msgstr "Eerder"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr "nog geen geschiedenis"
 
@@ -786,16 +803,16 @@ msgstr "Podcastlijsten van %(username)s"
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s heeft nog geen podcastlijsten gecreëerd."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr "Je moet een titel opgeven."
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr "\"{title}\" is geen geldige titel"
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr "Bedankt voor het beoordelen!"
 
@@ -835,24 +852,24 @@ msgstr "Toevoegen aan favorieten"
 msgid "Episode History"
 msgstr "Afleveringsgeschiedenis"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Naamloze podcast"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr "door"
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr "Feed"
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr "abonnees"
@@ -917,9 +934,9 @@ msgstr "Vervang 'YOUR_ADRESS' door het adres van je podcastfeed."
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "Adverteren"
 
@@ -991,21 +1008,6 @@ msgstr ""
 "podcasts. We kunnen echter geen vast bezoekersaantal garanderen tijdens de "
 "advertentieperiode."
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "Adverteren starten"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"Neem contact op met <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder."
-"net</a> als je wilt adverteren op %(sitename)s of als je vragen hebt. "
-"Betalingen worden verricht via PayPal aan thp@perli.net"
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "Naamloze aflevering"
@@ -1029,7 +1031,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr "Opslaan"
@@ -1048,7 +1050,7 @@ msgstr "Terug naar podcastpagina"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Afleveringen"
 
@@ -1136,11 +1138,11 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
-"Meer informatie is te vinden op de <a href=\"%(advertise-url)s"
-"\">adverteerpagina</a>."
+"Meer informatie is te vinden op de <a "
+"href=\"%(advertise-url)s\">adverteerpagina</a>."
 
 #: mygpo/publisher/templates/publisher/info.html:27
 #, python-format
@@ -1158,8 +1160,8 @@ msgstr ""
 #| "podcast listed on %(sitename)s, feel free to apply by sending a mail "
 #| "with\n"
 #| "  <ul>\n"
-#| "   <li>your username on %(sitename)s (<a href=\"%(register-url)s"
-#| "\">register if you don't have one</a>)</li>\n"
+#| "   <li>your username on %(sitename)s (<a "
+#| "href=\"%(register-url)s\">register if you don't have one</a>)</li>\n"
 #| "   <li>the name and URL of the podcast you are publishing</li>\n"
 #| "   <li>an email address that is visible somewhere on the podcast's "
 #| "website (to legitimate you)\n"
@@ -1181,8 +1183,9 @@ msgstr ""
 "je een podcast publiceert die genoemd wordt op %(sitename)s, dan kun je een "
 "e-mail sturen aan\n"
 "<ul>\n"
-"<li>met je gebruikersnaam op %(sitename)s (<a href=\"%(register-url)s"
-"\">registreer jezelf als je nog geen account hebt</a>)</li>,\n"
+"<li>met je gebruikersnaam op %(sitename)s (<a "
+"href=\"%(register-url)s\">registreer jezelf als je nog geen account hebt</"
+"a>)</li>,\n"
 "<li>de naam en URL van de podcast die je publiceert</li>\n"
 "<li>en een e-mailadres dat zichtbaar is op de podcastwebsite (om je "
 "identiteit vast te stellen)\n"
@@ -1253,8 +1256,8 @@ msgstr ""
 msgid "Update now"
 msgstr "Nu bijwerken"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -1322,11 +1325,11 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
-"We hebben de volgende licentie aangetroffen in je podcast: <a href="
-"\"%(license)s\">%(license)s</a>"
+"We hebben de volgende licentie aangetroffen in je podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
 msgid ""
@@ -1335,10 +1338,10 @@ msgid ""
 "practice.md#license\"> gPodder Podcast Feed Best Practice</a> on how to "
 "include license information."
 msgstr ""
-"We hebben geen licentie aangetroffen in je podcastfeed. Lees <a href="
-"\"https://github.com/gpodder/podcast-feed-best-practice/blob/master/podcast-"
-"feed-best-practice.md#license\">gPodder - podcastfeed-informatie</a> om meer "
-"te weten te komen over licentie-informatie."
+"We hebben geen licentie aangetroffen in je podcastfeed. Lees <a "
+"href=\"https://github.com/gpodder/podcast-feed-best-practice/blob/master/"
+"podcast-feed-best-practice.md#license\">gPodder - podcastfeed-informatie</a> "
+"om meer te weten te komen over licentie-informatie."
 
 #: mygpo/publisher/templates/publisher/podcast.html:208
 msgid "Link"
@@ -1348,7 +1351,7 @@ msgstr "Link"
 msgid "Show Group Stats"
 msgstr "Groepsstatistieken tonen"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
@@ -1356,15 +1359,15 @@ msgstr ""
 "De bijwerking is ingepland. Het kan even duren voordat de resultaten "
 "zichtbaar zijn."
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr "Gegevens bijgewerkt"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr "Uitgever-toegangssleutel bijgewerkt"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr "Slug {slug} verwijderd uit {episode}"
@@ -1437,8 +1440,8 @@ msgstr "Delen"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Abonnementen"
 
@@ -1453,7 +1456,7 @@ msgid "User Page"
 msgstr "Gebruikerspagina"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Instellingen"
 
@@ -1573,13 +1576,13 @@ msgstr "%(episode_count)s afleveringen"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
-"Je hebt nog geen abonnementen. Stel je <a href=\"%(devices)s"
-"\">podcastclients</a> in en <a href=\"%(directory)s\">ontdek interessante "
-"podcasts</a>."
+"Je hebt nog geen abonnementen. Stel je <a "
+"href=\"%(devices)s\">podcastclients</a> in en <a "
+"href=\"%(directory)s\">ontdek interessante podcasts</a>."
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
 #: mygpo/suggestions/templates/suggestions.html:54
@@ -1587,23 +1590,23 @@ msgstr ""
 msgid "Download OPML"
 msgstr "OPML downloaden"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "%(username)s's podcastabonnementen op %(site)s"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 "Recente wijzigen aan %(username)s's podcastabonnementenlijst op %(site)s"
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "%(username)s heeft zich geabonneerd op %(podcast)s (%(site)s)"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "%(username)s heeft zich gedeabonneerd op %(podcast)s (%(site)s)"
@@ -1621,27 +1624,27 @@ msgstr "Niet geïnteresseerd"
 msgid "No Suggestions Yet"
 msgstr "Nog geen aanbevelingen"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Desktop"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Laptop"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Mobiele telefoon"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Server"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr "Tablet"
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Overig"
 
@@ -1676,9 +1679,9 @@ msgid "You are already registered."
 msgstr "Je bent al geregistreerd."
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Registreren"
 
@@ -1700,8 +1703,8 @@ msgid ""
 "If it doesn't arrive, you can <a href=\"%(resend-activation-url)s\">resend</"
 "a> it."
 msgstr ""
-"Als de e-mail niet binnenkomt, dan kun je hem <a href="
-"\"%(resend-activation-url)s\">opnieuw versturen</a>."
+"Als de e-mail niet binnenkomt, dan kun je hem <a "
+"href=\"%(resend-activation-url)s\">opnieuw versturen</a>."
 
 #: mygpo/users/templates/registration/resend_activation.html:4
 #: mygpo/users/templates/registration/resend_activation.html:8
@@ -1762,130 +1765,118 @@ msgstr "Abonnementen kunnen niet worden geüpload: {err}"
 msgid "Your subscription will be updated in a moment."
 msgstr "Je abonnement wordt zometeen bijgewerkt."
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr "Gebruikersnaam of e-mailadres is al in gebruik"
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr "De activatielink is ongeldig of reeds verlopen."
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr "Je account is geactiveerd; je kunt nu inloggen."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr "Je gebruikersnaam of e-mailadres is vereist."
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "Account bestaat niet."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your account has been deleted"
+msgid "Your data has been archived."
+msgstr "Je account is verwijderd"
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "Je account is al geactiveerd. Ga door met inloggen."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr "Oeps! Er is iets misgegaan. Controleer de ingevoerde gegevens."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr "Je account is niet langer gekoppeld"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr "Gebruikersnaam ontbreekt"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr "Wachtwoord ontbreekt"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Onjuiste gebruikersnaam of wachtwoord."
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 "Activeer eerst je account. We hebben je activatie-e-mail opnieuw verstuurd."
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr "Inloggen mislukt."
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr "Inloggen met Google is momenteel niet mogelijk."
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-"Je account is gekoppeld aan {google}. Open de instellingen om dit te "
-"wijzigen."
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-"Er is geen account gekoppeld aan je Google-account '%s'. Log in om te "
-"koppelen."
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "E-mailadres"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Huidig wachtwoord"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "Wachtwoord bevestigen"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr "Vertel iets over jezelf"
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Naam"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Type"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "Apparaat-ID"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr "ID op apparaat"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "Deel dit abonnement met andere gebruikers (openbaar)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Geen apparaat geselecteerd"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Voer je gebruikersnaam in"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "of het e-mailadres dat je gebruikt hebt bij het registreren"
 
@@ -1927,110 +1918,97 @@ msgstr "Gekoppeld aan %(gmail)s"
 msgid "Disconnect"
 msgstr "Ontkoppelen"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr "Koppelen"
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "Account"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Inloggen"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr "Inloggen met Google"
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Ontdekken"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "Map"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr "Ondersteuning"
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr "Documentatie"
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr "Mailing&nbsp;lijst"
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr "Vragen"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr "Ondersteun&nbsp;ons"
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr "Doneren"
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr "Volgen"
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr "Blog"
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr "Blog&nbsp;(RSS)"
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr "Ontwikkelen"
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr "API"
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "Bibliotheken"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr "Clients"
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr "Publiceren"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr "Toegang&nbsp;verkrijgen"
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr "Link&npsb;naar&nbsp;ons"
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr "hosting geleverd door tornadovps.com"
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr "Bijdragen"
 
@@ -2053,26 +2031,32 @@ msgid "Work"
 msgstr "Werk"
 
 #: mygpo/web/templates/contribute.html:19
+#, fuzzy
+#| msgid ""
+#| "If you want to contribute to gpodder.net by writing code, check out the "
+#| "<a href=\"/developer/\">Development</a> page. We also appreciate "
+#| "contributions of non-coding work, such as web and interface design, "
+#| "server operations, testing, etc. If you are interested, join the <a "
+#| "href=\"https://gpodder.github.io/docs/mailing-list.html\">mailing list</"
+#| "a> or the IRC channel #gpodder on chat.freenode.net."
 msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 "Als je wilt bijdragen aan gpodder.net door het aanleveren van code, bekijk "
 "dan de pagina <a href=\"/developer/\">Ontwikkeling</a>. We zijn ook blij met "
 "andere soorten bijdragen, zoals het verbeteren van het ontwerp van de "
 "(web)client, serverhandelingen, testen, etc. Als je geïnteresseerd bent, "
-"abonneer je dan op de <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailinglijst</a> of ga naar het IRC-kanaal #gpodder op chat.freenode."
-"net"
+"abonneer je dan op de <a href=\"https://gpodder.github.io/docs/mailing-"
+"list.html\">mailinglijst</a> of ga naar het IRC-kanaal #gpodder op "
+"chat.freenode.net"
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2104,7 +2088,7 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nee"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "Overzicht"
 
@@ -2120,27 +2104,31 @@ msgstr "Nieuwste afleveringen"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
-"Welkom op %(site)s! Als dit je eerste keer is, dan moet je je <a href="
-"\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html\">podcast-"
-"client</a> instellen en zoveel mogelijk <em>Ontdek</em>-vakjes aankruisen "
-"als mogelijk."
+"Welkom op %(site)s! Als dit je eerste keer is, dan moet je je <a "
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast-client</a> instellen en zoveel mogelijk <em>Ontdek</"
+"em>-vakjes aankruisen als mogelijk."
 
 #: mygpo/web/templates/dashboard.html:44
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
+#| "ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-"
+#| "list.html\">mailing list</a> or <a href=\"https://github.com/gpodder/"
+#| "mygpo/issues\">forum</a>."
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 "Als je problemen hebt, bekijk dan de <a href=\"%(help)s\">documentatie</a> "
-"of stel vragen op de <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailinglijst</a> of het <a href=\"https://github.com/gpodder/mygpo/"
-"issues\">forum</a>."
+"of stel vragen op de <a href=\"https://gpodder.github.io/docs/mailing-"
+"list.html\">mailinglijst</a> of het <a href=\"https://github.com/gpodder/"
+"mygpo/issues\">forum</a>."
 
 #: mygpo/web/templates/dashboard.html:81
 #, python-format
@@ -2230,7 +2218,7 @@ msgid "Thanks"
 msgstr "Bedankt"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr "Ontwikkeling"
 
@@ -2243,8 +2231,9 @@ msgstr "Webdienst"
 #| msgid ""
 #| "The sourcecode of the webservice gpodder.net is released as open source "
 #| "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted "
-#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://bugs.gpodder."
-#| "org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
+#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://"
+#| "bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</"
+#| "a>."
 msgid ""
 "The sourcecode of the webservice gpodder.net is released as open source "
 "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted at "
@@ -2252,9 +2241,10 @@ msgid ""
 "gpodder/issues\">gPodder Issue Tracker on GitHub</a>."
 msgstr ""
 "De broncode van de webdienst gpodder.net is vrijgegeven en uitgebracht onder "
-"de AGPLv3-licentie en wordt <a href=\"https://github.com/gpodder/mygpo"
-"\">gehost op GitHub</a>. Bugs kunnen worden gemeld op de <a href=\"https://"
-"bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder-bugtracker</a>."
+"de AGPLv3-licentie en wordt <a href=\"https://github.com/gpodder/"
+"mygpo\">gehost op GitHub</a>. Bugs kunnen worden gemeld op de <a "
+"href=\"https://bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder-"
+"bugtracker</a>."
 
 #: mygpo/web/templates/developer.html:21
 msgid "Integrating Clients"
@@ -2370,13 +2360,13 @@ msgstr "Niet-gesynchroniseerd"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
-"Je hebt nog geen apparaten. Ga naar de pagina <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> om meer informatie "
-"te verkrijgen over het instellen van je client-apps."
+"Je hebt nog geen apparaten. Ga naar de pagina <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> om meer "
+"informatie te verkrijgen over het instellen van je client-apps."
 
 #: mygpo/web/templates/devicelist.html:74
 msgid "Deleted Devices"
@@ -2391,7 +2381,7 @@ msgid "Delete Permanently"
 msgstr "Permanent verwijderen"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "Favoriete afleveringen"
 
@@ -2418,18 +2408,18 @@ msgstr ""
 "opnieuw!"
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "Mijn labels"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"Je hebt nog geen podcasts gelabeld. Ga naar je <a href="
-"\"%(subscriptions-url)s\">abonnementen</a> om podcasts te labelen."
+"Je hebt nog geen podcasts gelabeld. Ga naar je <a "
+"href=\"%(subscriptions-url)s\">abonnementen</a> om podcasts te labelen."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2442,8 +2432,8 @@ msgstr "Je wachtwoord is hersteld"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 "Je zou een e-mail moeten hebben ontvangen met daarin je nieuwe wachtwoord. "
 "<a href=\"%(login-url)s\">Log nu in</a>."
@@ -2506,7 +2496,7 @@ msgstr "Privé-abonnementen"
 msgid "Make Public"
 msgstr "Openbaar maken"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr "Privacybeleid"
 
@@ -2552,6 +2542,17 @@ msgid ""
 msgstr ""
 "Omdat we namen pas tonen nadat we de informatie hebben opgehaald uit de feed "
 "-- dit kan even duren.  De podcast is naamloos totdat dit proces is afgerond."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Activate User"
+msgid "Archived User"
+msgstr "Gebruiker activeren"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2707,47 +2708,51 @@ msgstr "Deze aflevering is verwijderd"
 msgid "Unknown Episode"
 msgstr "Onbekende aflevering"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Startpagina"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Hulp"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "Gebruikersabonnementen"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Aanbevelingen"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr "Functies"
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr "Toplijsten"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Apparaten"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr "Gemeenschap"
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr "Mijn gebruikerspagina"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Privacy"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "Link naar gpodder.net"
 
@@ -2762,51 +2767,96 @@ msgstr "{h}h {m}m {s}s"
 msgid "{m}m {s}s"
 msgstr "{h}h {m}m {s}s"
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] "%(weeks)d week"
 msgstr[1] "%(weeks)d weken"
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] "%(days)d dag"
 msgstr[1] "%(days)d dagen"
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] "%(hours)d uur"
 msgstr[1] "%(hours)d uur"
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "een andere site"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "Adverteren starten"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "Neem contact op met <a "
+#~ "href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> als je wilt "
+#~ "adverteren op %(sitename)s of als je vragen hebt. Betalingen worden "
+#~ "verricht via PayPal aan thp@perli.net"
+
+#~ msgid "Login failed."
+#~ msgstr "Inloggen mislukt."
+
+#~ msgid "Login with Google is currently not possible."
+#~ msgstr "Inloggen met Google is momenteel niet mogelijk."
+
+#, python-brace-format
+#~ msgid ""
+#~ "Your account has been connected with {google}. Open Settings to change "
+#~ "this."
+#~ msgstr ""
+#~ "Je account is gekoppeld aan {google}. Open de instellingen om dit te "
+#~ "wijzigen."
+
+#, python-format
+#~ msgid ""
+#~ "No account connected with your Google account %s. Please log in to "
+#~ "connect."
+#~ msgstr ""
+#~ "Er is geen account gekoppeld aan je Google-account '%s'. Log in om te "
+#~ "koppelen."
+
+#~ msgid "Connect"
+#~ msgstr "Koppelen"
+
+#~ msgid "Login with Google"
+#~ msgstr "Inloggen met Google"
+
+#~ msgid "Mailing&nbsp;List"
+#~ msgstr "Mailing&nbsp;lijst"
 
 #, fuzzy
 #~| msgid ""
 #~| "If you want to support gpodder.net financially, you can donate via "
 #~| "PayPal to stefan@skoegl.net. You can also send a book via Amazon (<a "
-#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href="
-#~| "\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www."
-#~| "amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~| "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~| "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 #~ msgid ""
 #~ "If you want to support gpodder.net financially, you can donate via <a "
 #~ "href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>. You can also "
-#~ "send a book via Amazon (<a href=\"http://www.amazon.de/"
-#~ "wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R"
-#~ "\">US</a> or <a href=\"http://www.amazon.co.uk/registry/"
-#~ "wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "send a book via Amazon (<a href=\"http://www.amazon.de/wishlist/"
+#~ "24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</"
+#~ "a> or <a href=\"http://www.amazon.co.uk/registry/wishlist/"
+#~ "24JRVURXUKO6F\">UK</a>)."
 #~ msgstr ""
 #~ "Als je gpodder.net financieel wilt ondersteunen, dan kun je doneren via "
 #~ "PayPal aan stefan@skoegl.net Je kunt ook een boek sturen via Amazon (<a "
-#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href="
-#~ "\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> of <a href=\"http://www.amazon."
-#~ "co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~ "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> of <a href=\"http://"
+#~ "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 
 #~ msgid "Timing"
 #~ msgstr "Timing"

--- a/mygpo/locale/nl_NL/LC_MESSAGES/django.po
+++ b/mygpo/locale/nl_NL/LC_MESSAGES/django.po
@@ -11,11 +11,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2018-06-20 06:29+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>, 2018\n"
-"Language-Team: Dutch (Netherlands) (https://www.transifex.com/yaron/"
-"teams/87581/nl_NL/)\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/yaron/teams/"
+"87581/nl_NL/)\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,7 +31,7 @@ msgstr "Gebruiker activeren"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Gebruikersnaam"
 
@@ -157,7 +157,7 @@ msgstr "Ingeplande Celery-taken"
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr "Uitgeversmachtigingen"
 
@@ -194,7 +194,11 @@ msgstr "Als je vragen hebt, ga dan naar %(url)s"
 msgid "Merge Podcasts and Episodes"
 msgstr "Podcasts en afleveringen samenvoegen"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -289,25 +293,37 @@ msgstr "Verversen"
 msgid "User-Agent"
 msgstr "Gebruikersagent"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "Geen podcast met de URL {url}"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr "Geef een gebruikersnaam of e-mailadres op"
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr "Geen gebruiker gevonden"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr "Gebruiker {username} ({email}) is geactiveerd"
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} is already activated"
+msgstr "Gebruiker {username} ({email}) is geactiveerd"
+
+#: mygpo/administration/views.py:383
+#, fuzzy, python-brace-format
+#| msgid "User {username} ({email}) activated"
+msgid "User {username} data has been archived."
+msgstr "Gebruiker {username} ({email}) is geactiveerd"
+
+#: mygpo/administration/views.py:389
 #, fuzzy, python-brace-format
 #| msgid "User {username} ({email}) activated"
 msgid "Email for {username} ({email}) resent"
@@ -390,11 +406,11 @@ msgstr "Podcastmap"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"%(listtitle)s <span class=\"by-user\">door <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">door <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -453,8 +469,8 @@ msgstr "Licentie tonen"
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podcast"
 
@@ -477,14 +493,14 @@ msgid "Podcasts with License Information"
 msgstr "Podcasts met licentie-informatie"
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr "Licentie"
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr "Podcasts"
 
@@ -531,7 +547,7 @@ msgid "OK"
 msgstr "Oké"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr "Ontbrekende podcast"
 
@@ -564,7 +580,7 @@ msgstr "Gesponsorde podcast"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr "Podcastlijsten"
 
@@ -580,6 +596,7 @@ msgstr "Gebruiker"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "Downloaden"
 
@@ -598,8 +615,8 @@ msgstr "Creëer een lijst met podcasts over een onderwerp dat je interesseert"
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Zoeken"
 
@@ -631,20 +648,20 @@ msgstr "Toplijst"
 msgid "Client Access"
 msgstr "Client-toegang"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr "%d podcasts toegevoegd"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Geschiedenis"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -665,7 +682,7 @@ msgid "Action"
 msgstr "Actie"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Apparaat"
 
@@ -675,7 +692,7 @@ msgstr "Toevoegen"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr "Abonnementsgeschiedenis"
@@ -709,7 +726,7 @@ msgstr "Nu"
 msgid "Earlier"
 msgstr "Eerder"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr "nog geen geschiedenis"
 
@@ -789,16 +806,16 @@ msgstr "Podcastlijsten van %(username)s"
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s heeft nog geen podcastlijsten gecreëerd."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr "Je moet een titel opgeven."
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr "\"{title}\" is geen geldige titel"
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr "Bedankt voor het beoordelen!"
 
@@ -838,24 +855,24 @@ msgstr "Toevoegen aan favorieten"
 msgid "Episode History"
 msgstr "Afleveringsgeschiedenis"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Naamloze podcast"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr "door"
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr "Feed"
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr "abonnees"
@@ -920,9 +937,9 @@ msgstr "Vervang 'YOUR_ADRESS' door het adres van je podcastfeed."
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "Adverteren"
 
@@ -994,21 +1011,6 @@ msgstr ""
 "podcasts. We kunnen echter geen vast bezoekersaantal garanderen tijdens de "
 "advertentieperiode."
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "Adverteren starten"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"Neem contact op met <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder."
-"net</a> als je wilt adverteren op %(sitename)s of als je vragen hebt. "
-"Betalingen worden verricht via PayPal aan thp@perli.net"
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "Naamloze aflevering"
@@ -1032,7 +1034,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr "Opslaan"
@@ -1051,7 +1053,7 @@ msgstr "Terug naar podcastpagina"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Afleveringen"
 
@@ -1139,11 +1141,11 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
-"Meer informatie is te vinden op de <a href=\"%(advertise-url)s"
-"\">adverteerpagina</a>."
+"Meer informatie is te vinden op de <a "
+"href=\"%(advertise-url)s\">adverteerpagina</a>."
 
 #: mygpo/publisher/templates/publisher/info.html:27
 #, python-format
@@ -1161,8 +1163,8 @@ msgstr ""
 #| "podcast listed on %(sitename)s, feel free to apply by sending a mail "
 #| "with\n"
 #| "  <ul>\n"
-#| "   <li>your username on %(sitename)s (<a href=\"%(register-url)s"
-#| "\">register if you don't have one</a>)</li>\n"
+#| "   <li>your username on %(sitename)s (<a "
+#| "href=\"%(register-url)s\">register if you don't have one</a>)</li>\n"
 #| "   <li>the name and URL of the podcast you are publishing</li>\n"
 #| "   <li>an email address that is visible somewhere on the podcast's "
 #| "website (to legitimate you)\n"
@@ -1184,8 +1186,9 @@ msgstr ""
 "je een podcast publiceert die genoemd wordt op %(sitename)s, dan kun je een "
 "e-mail sturen aan\n"
 "<ul>\n"
-"<li>met je gebruikersnaam op %(sitename)s (<a href=\"%(register-url)s"
-"\">registreer jezelf als je nog geen account hebt</a>)</li>,\n"
+"<li>met je gebruikersnaam op %(sitename)s (<a "
+"href=\"%(register-url)s\">registreer jezelf als je nog geen account hebt</"
+"a>)</li>,\n"
 "<li>de naam en URL van de podcast die je publiceert</li>\n"
 "<li>en een e-mailadres dat zichtbaar is op de podcastwebsite (om je "
 "identiteit vast te stellen)\n"
@@ -1256,8 +1259,8 @@ msgstr ""
 msgid "Update now"
 msgstr "Nu bijwerken"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -1325,11 +1328,11 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
-"We hebben de volgende licentie aangetroffen in je podcast: <a href="
-"\"%(license)s\">%(license)s</a>"
+"We hebben de volgende licentie aangetroffen in je podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
 msgid ""
@@ -1338,10 +1341,10 @@ msgid ""
 "practice.md#license\"> gPodder Podcast Feed Best Practice</a> on how to "
 "include license information."
 msgstr ""
-"We hebben geen licentie aangetroffen in je podcastfeed. Lees <a href="
-"\"https://github.com/gpodder/podcast-feed-best-practice/blob/master/podcast-"
-"feed-best-practice.md#license\">gPodder - podcastfeed-informatie</a> om meer "
-"te weten te komen over licentie-informatie."
+"We hebben geen licentie aangetroffen in je podcastfeed. Lees <a "
+"href=\"https://github.com/gpodder/podcast-feed-best-practice/blob/master/"
+"podcast-feed-best-practice.md#license\">gPodder - podcastfeed-informatie</a> "
+"om meer te weten te komen over licentie-informatie."
 
 #: mygpo/publisher/templates/publisher/podcast.html:208
 msgid "Link"
@@ -1351,7 +1354,7 @@ msgstr "Link"
 msgid "Show Group Stats"
 msgstr "Groepsstatistieken tonen"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
@@ -1359,15 +1362,15 @@ msgstr ""
 "De bijwerking is ingepland. Het kan even duren voordat de resultaten "
 "zichtbaar zijn."
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr "Gegevens bijgewerkt"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr "Uitgever-toegangssleutel bijgewerkt"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr "Slug {slug} verwijderd uit {episode}"
@@ -1440,8 +1443,8 @@ msgstr "Delen"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Abonnementen"
 
@@ -1456,7 +1459,7 @@ msgid "User Page"
 msgstr "Gebruikerspagina"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Instellingen"
 
@@ -1576,13 +1579,13 @@ msgstr "%(episode_count)s afleveringen"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
-"Je hebt nog geen abonnementen. Stel je <a href=\"%(devices)s"
-"\">podcastclients</a> in en <a href=\"%(directory)s\">ontdek interessante "
-"podcasts</a>."
+"Je hebt nog geen abonnementen. Stel je <a "
+"href=\"%(devices)s\">podcastclients</a> in en <a "
+"href=\"%(directory)s\">ontdek interessante podcasts</a>."
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
 #: mygpo/suggestions/templates/suggestions.html:54
@@ -1590,23 +1593,23 @@ msgstr ""
 msgid "Download OPML"
 msgstr "OPML downloaden"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "%(username)s's podcastabonnementen op %(site)s"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 "Recente wijzigen aan %(username)s's podcastabonnementenlijst op %(site)s"
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "%(username)s heeft zich geabonneerd op %(podcast)s (%(site)s)"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "%(username)s heeft zich gedeabonneerd op %(podcast)s (%(site)s)"
@@ -1624,27 +1627,27 @@ msgstr "Niet geïnteresseerd"
 msgid "No Suggestions Yet"
 msgstr "Nog geen aanbevelingen"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Desktop"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Laptop"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Mobiele telefoon"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Server"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr "Tablet"
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Overig"
 
@@ -1679,9 +1682,9 @@ msgid "You are already registered."
 msgstr "Je bent al geregistreerd."
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Registreren"
 
@@ -1703,8 +1706,8 @@ msgid ""
 "If it doesn't arrive, you can <a href=\"%(resend-activation-url)s\">resend</"
 "a> it."
 msgstr ""
-"Als de e-mail niet binnenkomt, dan kun je hem <a href="
-"\"%(resend-activation-url)s\">opnieuw versturen</a>."
+"Als de e-mail niet binnenkomt, dan kun je hem <a "
+"href=\"%(resend-activation-url)s\">opnieuw versturen</a>."
 
 #: mygpo/users/templates/registration/resend_activation.html:4
 #: mygpo/users/templates/registration/resend_activation.html:8
@@ -1765,130 +1768,118 @@ msgstr "Abonnementen kunnen niet worden geüpload: {err}"
 msgid "Your subscription will be updated in a moment."
 msgstr "Je abonnement wordt zometeen bijgewerkt."
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr "Gebruikersnaam of e-mailadres is al in gebruik"
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr "De activatielink is ongeldig of reeds verlopen."
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr "Je account is geactiveerd; je kunt nu inloggen."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr "Je gebruikersnaam of e-mailadres is vereist."
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "Account bestaat niet."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your account has been deleted"
+msgid "Your data has been archived."
+msgstr "Je account is verwijderd"
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "Je account is al geactiveerd. Ga door met inloggen."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr "Oeps! Er is iets misgegaan. Controleer de ingevoerde gegevens."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr "Je account is niet langer gekoppeld"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr "Gebruikersnaam ontbreekt"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr "Wachtwoord ontbreekt"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Onjuiste gebruikersnaam of wachtwoord."
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 "Activeer eerst je account. We hebben je activatie-e-mail opnieuw verstuurd."
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr "Inloggen mislukt."
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr "Inloggen met Google is momenteel niet mogelijk."
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-"Je account is gekoppeld aan {google}. Open de instellingen om dit te "
-"wijzigen."
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-"Er is geen account gekoppeld aan je Google-account '%s'. Log in om te "
-"koppelen."
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "E-mailadres"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Huidig wachtwoord"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Nieuw wachtwoord"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "Wachtwoord bevestigen"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr "Vertel iets over jezelf"
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Naam"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Type"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "Apparaat-ID"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr "ID op apparaat"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "Deel dit abonnement met andere gebruikers (openbaar)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Geen apparaat geselecteerd"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Voer je gebruikersnaam in"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "of het e-mailadres dat je gebruikt hebt bij het registreren"
 
@@ -1930,110 +1921,97 @@ msgstr "Gekoppeld aan %(gmail)s"
 msgid "Disconnect"
 msgstr "Ontkoppelen"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr "Koppelen"
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "Account"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Inloggen"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr "Inloggen met Google"
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Ontdekken"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "Map"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr "Ondersteuning"
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr "Documentatie"
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr "Mailing&nbsp;lijst"
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr "Vragen"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr "Ondersteun&nbsp;ons"
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr "Doneren"
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr "Volgen"
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr "Blog"
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr "Blog&nbsp;(RSS)"
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr "Ontwikkelen"
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr "API"
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "Bibliotheken"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr "Clients"
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr "Publiceren"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr "Toegang&nbsp;verkrijgen"
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr "Link&npsb;naar&nbsp;ons"
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr "hosting geleverd door tornadovps.com"
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr "Bijdragen"
 
@@ -2056,26 +2034,32 @@ msgid "Work"
 msgstr "Werk"
 
 #: mygpo/web/templates/contribute.html:19
+#, fuzzy
+#| msgid ""
+#| "If you want to contribute to gpodder.net by writing code, check out the "
+#| "<a href=\"/developer/\">Development</a> page. We also appreciate "
+#| "contributions of non-coding work, such as web and interface design, "
+#| "server operations, testing, etc. If you are interested, join the <a "
+#| "href=\"https://gpodder.github.io/docs/mailing-list.html\">mailing list</"
+#| "a> or the IRC channel #gpodder on chat.freenode.net."
 msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 "Als je wilt bijdragen aan gpodder.net door het aanleveren van code, bekijk "
 "dan de pagina <a href=\"/developer/\">Ontwikkeling</a>. We zijn ook blij met "
 "andere soorten bijdragen, zoals het verbeteren van het ontwerp van de "
 "(web)client, serverhandelingen, testen, etc. Als je geïnteresseerd bent, "
-"abonneer je dan op de <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailinglijst</a> of ga naar het IRC-kanaal #gpodder op chat.freenode."
-"net"
+"abonneer je dan op de <a href=\"https://gpodder.github.io/docs/mailing-"
+"list.html\">mailinglijst</a> of ga naar het IRC-kanaal #gpodder op "
+"chat.freenode.net"
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2107,7 +2091,7 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nee"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "Overzicht"
 
@@ -2123,27 +2107,31 @@ msgstr "Nieuwste afleveringen"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
-"Welkom op %(site)s! Als dit je eerste keer is, dan moet je je <a href="
-"\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html\">podcast-"
-"client</a> instellen en zoveel mogelijk <em>Ontdek</em>-vakjes aankruisen "
-"als mogelijk."
+"Welkom op %(site)s! Als dit je eerste keer is, dan moet je je <a "
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast-client</a> instellen en zoveel mogelijk <em>Ontdek</"
+"em>-vakjes aankruisen als mogelijk."
 
 #: mygpo/web/templates/dashboard.html:44
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
+#| "ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-"
+#| "list.html\">mailing list</a> or <a href=\"https://github.com/gpodder/"
+#| "mygpo/issues\">forum</a>."
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 "Als je problemen hebt, bekijk dan de <a href=\"%(help)s\">documentatie</a> "
-"of stel vragen op de <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailinglijst</a> of het <a href=\"https://github.com/gpodder/mygpo/"
-"issues\">forum</a>."
+"of stel vragen op de <a href=\"https://gpodder.github.io/docs/mailing-"
+"list.html\">mailinglijst</a> of het <a href=\"https://github.com/gpodder/"
+"mygpo/issues\">forum</a>."
 
 #: mygpo/web/templates/dashboard.html:81
 #, python-format
@@ -2233,7 +2221,7 @@ msgid "Thanks"
 msgstr "Bedankt"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr "Ontwikkeling"
 
@@ -2246,8 +2234,9 @@ msgstr "Webdienst"
 #| msgid ""
 #| "The sourcecode of the webservice gpodder.net is released as open source "
 #| "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted "
-#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://bugs.gpodder."
-#| "org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
+#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://"
+#| "bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</"
+#| "a>."
 msgid ""
 "The sourcecode of the webservice gpodder.net is released as open source "
 "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted at "
@@ -2255,9 +2244,10 @@ msgid ""
 "gpodder/issues\">gPodder Issue Tracker on GitHub</a>."
 msgstr ""
 "De broncode van de webdienst gpodder.net is vrijgegeven en uitgebracht onder "
-"de AGPLv3-licentie en wordt <a href=\"https://github.com/gpodder/mygpo"
-"\">gehost op GitHub</a>. Bugs kunnen worden gemeld op de <a href=\"https://"
-"bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder-bugtracker</a>."
+"de AGPLv3-licentie en wordt <a href=\"https://github.com/gpodder/"
+"mygpo\">gehost op GitHub</a>. Bugs kunnen worden gemeld op de <a "
+"href=\"https://bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder-"
+"bugtracker</a>."
 
 #: mygpo/web/templates/developer.html:21
 msgid "Integrating Clients"
@@ -2373,13 +2363,13 @@ msgstr "Niet-gesynchroniseerd"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
-"Je hebt nog geen apparaten. Ga naar de pagina <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> om meer informatie "
-"te verkrijgen over het instellen van je client-apps."
+"Je hebt nog geen apparaten. Ga naar de pagina <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> om meer "
+"informatie te verkrijgen over het instellen van je client-apps."
 
 #: mygpo/web/templates/devicelist.html:74
 msgid "Deleted Devices"
@@ -2394,7 +2384,7 @@ msgid "Delete Permanently"
 msgstr "Permanent verwijderen"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "Favoriete afleveringen"
 
@@ -2421,18 +2411,18 @@ msgstr ""
 "opnieuw!"
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "Mijn labels"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"Je hebt nog geen podcasts gelabeld. Ga naar je <a href="
-"\"%(subscriptions-url)s\">abonnementen</a> om podcasts te labelen."
+"Je hebt nog geen podcasts gelabeld. Ga naar je <a "
+"href=\"%(subscriptions-url)s\">abonnementen</a> om podcasts te labelen."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2445,8 +2435,8 @@ msgstr "Je wachtwoord is hersteld"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 "Je zou een e-mail moeten hebben ontvangen met daarin je nieuwe wachtwoord. "
 "<a href=\"%(login-url)s\">Log nu in</a>."
@@ -2509,7 +2499,7 @@ msgstr "Privé-abonnementen"
 msgid "Make Public"
 msgstr "Openbaar maken"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr "Privacybeleid"
 
@@ -2555,6 +2545,17 @@ msgid ""
 msgstr ""
 "Omdat we namen pas tonen nadat we de informatie hebben opgehaald uit de feed "
 "-- dit kan even duren.  De podcast is naamloos totdat dit proces is afgerond."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Activate User"
+msgid "Archived User"
+msgstr "Gebruiker activeren"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2710,47 +2711,51 @@ msgstr "Deze aflevering is verwijderd"
 msgid "Unknown Episode"
 msgstr "Onbekende aflevering"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Startpagina"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Hulp"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "Gebruikersabonnementen"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Aanbevelingen"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr "Functies"
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr "Toplijsten"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Apparaten"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr "Gemeenschap"
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr "Mijn gebruikerspagina"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Privacy"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "Link naar gpodder.net"
 
@@ -2765,30 +2770,75 @@ msgstr "{h}h {m}m {s}s"
 msgid "{m}m {s}s"
 msgstr "{h}h {m}m {s}s"
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] "%(weeks)d week"
 msgstr[1] "%(weeks)d weken"
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] "%(days)d dag"
 msgstr[1] "%(days)d dagen"
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] "%(hours)d uur"
 msgstr[1] "%(hours)d uur"
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "een andere site"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "Adverteren starten"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "Neem contact op met <a "
+#~ "href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> als je wilt "
+#~ "adverteren op %(sitename)s of als je vragen hebt. Betalingen worden "
+#~ "verricht via PayPal aan thp@perli.net"
+
+#~ msgid "Login failed."
+#~ msgstr "Inloggen mislukt."
+
+#~ msgid "Login with Google is currently not possible."
+#~ msgstr "Inloggen met Google is momenteel niet mogelijk."
+
+#, python-brace-format
+#~ msgid ""
+#~ "Your account has been connected with {google}. Open Settings to change "
+#~ "this."
+#~ msgstr ""
+#~ "Je account is gekoppeld aan {google}. Open de instellingen om dit te "
+#~ "wijzigen."
+
+#, python-format
+#~ msgid ""
+#~ "No account connected with your Google account %s. Please log in to "
+#~ "connect."
+#~ msgstr ""
+#~ "Er is geen account gekoppeld aan je Google-account '%s'. Log in om te "
+#~ "koppelen."
+
+#~ msgid "Connect"
+#~ msgstr "Koppelen"
+
+#~ msgid "Login with Google"
+#~ msgstr "Inloggen met Google"
+
+#~ msgid "Mailing&nbsp;List"
+#~ msgstr "Mailing&nbsp;lijst"
 
 #~ msgid "Timing"
 #~ msgstr "Timing"
@@ -2801,13 +2851,13 @@ msgstr "een andere site"
 
 #~ msgid ""
 #~ "If you want to support gpodder.net financially, you can donate via PayPal "
-#~ "to stefan@skoegl.net. You can also send a book via Amazon (<a href="
-#~ "\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://"
-#~ "amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www.amazon.co.uk/"
-#~ "registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "to stefan@skoegl.net. You can also send a book via Amazon (<a "
+#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~ "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~ "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 #~ msgstr ""
 #~ "Als je gpodder.net financieel wilt ondersteunen, dan kun je doneren via "
 #~ "PayPal aan stefan@skoegl.net Je kunt ook een boek sturen via Amazon (<a "
-#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href="
-#~ "\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> of <a href=\"http://www.amazon."
-#~ "co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~ "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> of <a href=\"http://"
+#~ "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."

--- a/mygpo/locale/no/LC_MESSAGES/django.po
+++ b/mygpo/locale/no/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2018-10-28 18:17+0000\n"
 "Language-Team: Norwegian (https://www.transifex.com/gpoddernet/teams/93001/"
 "no/)\n"
@@ -27,7 +27,7 @@ msgstr ""
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr ""
 
@@ -188,7 +188,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr ""
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -276,25 +280,35 @@ msgstr ""
 msgid "User-Agent"
 msgstr ""
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr ""
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr ""
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -376,8 +390,8 @@ msgstr ""
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
 
 #: mygpo/directory/templates/directory.html:46
@@ -437,8 +451,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr ""
 
@@ -461,14 +475,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr ""
 
@@ -515,7 +529,7 @@ msgid "OK"
 msgstr ""
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr ""
 
@@ -546,7 +560,7 @@ msgstr ""
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr ""
 
@@ -562,6 +576,7 @@ msgstr ""
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr ""
 
@@ -580,8 +595,8 @@ msgstr ""
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr ""
 
@@ -613,20 +628,20 @@ msgstr ""
 msgid "Client Access"
 msgstr ""
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, python-format
 msgid "%d podcasts added"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 msgid "Website"
@@ -647,7 +662,7 @@ msgid "Action"
 msgstr ""
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr ""
 
@@ -657,7 +672,7 @@ msgstr ""
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr ""
@@ -691,7 +706,7 @@ msgstr ""
 msgid "Earlier"
 msgstr ""
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -769,16 +784,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -818,24 +833,24 @@ msgstr ""
 msgid "Episode History"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr ""
@@ -898,9 +913,9 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr ""
 
@@ -957,18 +972,6 @@ msgid ""
 "advertisement period."
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr ""
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr ""
@@ -989,7 +992,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1008,7 +1011,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr ""
 
@@ -1090,8 +1093,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/info.html:27
@@ -1171,8 +1174,8 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1227,8 +1230,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1247,21 +1250,21 @@ msgstr ""
 msgid "Show Group Stats"
 msgstr ""
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1330,8 +1333,8 @@ msgstr ""
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr ""
 
@@ -1346,7 +1349,7 @@ msgid "User Page"
 msgstr ""
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr ""
 
@@ -1459,9 +1462,9 @@ msgstr ""
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1470,22 +1473,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr ""
@@ -1503,27 +1506,27 @@ msgstr ""
 msgid "No Suggestions Yet"
 msgstr ""
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr ""
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr ""
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr ""
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr ""
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr ""
 
@@ -1558,9 +1561,9 @@ msgid "You are already registered."
 msgstr ""
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr ""
 
@@ -1636,125 +1639,115 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr ""
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr ""
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+msgid "Your data has been archived."
+msgstr ""
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr ""
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr ""
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 msgid "Username missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 msgid "Password missing"
 msgstr ""
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr ""
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr ""
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr ""
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr ""
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr ""
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr ""
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr ""
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr ""
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr ""
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 msgid "ID on device"
 msgstr ""
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr ""
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr ""
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr ""
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr ""
 
@@ -1796,110 +1789,97 @@ msgstr ""
 msgid "Disconnect"
 msgstr ""
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr ""
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr ""
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr ""
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr ""
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr ""
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr ""
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr ""
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -1923,15 +1903,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -1959,7 +1937,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr ""
 
@@ -1975,18 +1953,17 @@ msgstr ""
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2075,7 +2052,7 @@ msgid "Thanks"
 msgstr ""
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2194,9 +2171,9 @@ msgstr ""
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2212,7 +2189,7 @@ msgid "Delete Permanently"
 msgstr ""
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr ""
 
@@ -2236,15 +2213,15 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
 
 #: mygpo/web/templates/password_reset.html:4
@@ -2258,8 +2235,8 @@ msgstr ""
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 
 #: mygpo/web/templates/password_reset_failed.html:4
@@ -2315,7 +2292,7 @@ msgstr ""
 msgid "Make Public"
 msgstr ""
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr ""
 
@@ -2347,6 +2324,15 @@ msgid ""
 "Because we display names after we have fetched the information from the feed "
 "-- and this may take some time. Until this is completed, the podcast will "
 "simply be called this way."
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+msgid "Archived User"
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
 msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
@@ -2494,47 +2480,51 @@ msgstr ""
 msgid "Unknown Episode"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr ""
 
@@ -2548,27 +2538,27 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr ""

--- a/mygpo/locale/pl/LC_MESSAGES/django.po
+++ b/mygpo/locale/pl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mygpo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2010-01-27 17:38+0100\n"
 "Last-Translator: Tomasz Dominikowski <dominikowski@gmail.com>\n"
 "Language-Team: Polish <dominikowski@gmail.com>\n"
@@ -29,7 +29,7 @@ msgstr "Reaktywuj"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
@@ -163,7 +163,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 #, fuzzy
 #| msgid "Publisher Pages"
 msgid "Publisher Permissions"
@@ -203,7 +203,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr "Podcasty"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -303,26 +307,36 @@ msgstr ""
 msgid "User-Agent"
 msgstr "User-Agent"
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr "Brak podcastu z URL {url}"
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 #, fuzzy
 msgid "No user found"
 msgstr "Nie odnaleziono"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -409,11 +423,11 @@ msgstr "Dla autorów podcastów"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
-"%(listtitle)s <span class=\"by-user\">przez <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">przez <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 
 #: mygpo/directory/templates/directory.html:46
 #: mygpo/directory/templates/directory.html:48
@@ -477,8 +491,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podcast"
 
@@ -502,14 +516,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 #, fuzzy
 msgid "Podcasts"
 msgstr "Podcast"
@@ -559,7 +573,7 @@ msgid "OK"
 msgstr "OK"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 #, fuzzy
 msgid "Missing Podcast"
 msgstr "Sugerowane podcasty"
@@ -593,7 +607,7 @@ msgstr "Sugerowane podcasty"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 #, fuzzy
 msgid "Podcast Lists"
 msgstr "Podcasty"
@@ -611,6 +625,7 @@ msgstr "Użytkownik"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr "Pobierz"
 
@@ -629,8 +644,8 @@ msgstr "Stwórz listę podcastów na temat, który lubisz"
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Wyszukaj"
 
@@ -665,20 +680,20 @@ msgstr "Lista najlepszych"
 msgid "Client Access"
 msgstr "Dostęp klienta"
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, fuzzy, python-format
 msgid "%d podcasts added"
 msgstr "Podcasty"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Historia"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 #, fuzzy
@@ -702,7 +717,7 @@ msgid "Action"
 msgstr "Działanie"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Urządzenie"
 
@@ -712,7 +727,7 @@ msgstr "Dodaj"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 #, fuzzy
 msgid "Subscription History"
@@ -747,7 +762,7 @@ msgstr "Teraz"
 msgid "Earlier"
 msgstr "Wcześniej"
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -831,16 +846,16 @@ msgstr "Lista podcastów od %(username)s"
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s nie stworzył jeszcze żadnej listy podcastów."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr "Musisz podać tytuł."
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr "\"{title}\" nie jest prawidłowym tytułem"
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr "Dzięki za ocenę!"
 
@@ -884,24 +899,24 @@ msgstr "Ulubione"
 msgid "Episode History"
 msgstr "Historia odcinków"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Podcast bez nazwy"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr "Kanał"
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 #, fuzzy
 msgid "subscribers"
@@ -976,9 +991,9 @@ msgstr "Wprowadź adres twojego podcastu w polu \"YOUR_ADRESS\"."
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "Reklamuj się"
 
@@ -1051,21 +1066,6 @@ msgstr ""
 "jednak nie gwarantujemy określonej liczby odwiedzających w czasie Twojego "
 "okresu reklamowego."
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "Rozpocznij swoją reklamę"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"Skontaktuj się z <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</"
-"a> jeśli chciałbyś reklamować się na %(sitename)s lub jeżeli masz jakieś "
-"pytania. Płatności są dokonywane przez PayPal do thp@perli.net."
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 #, fuzzy
 msgid "Unnamed Episode"
@@ -1089,7 +1089,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr "Zapisz"
@@ -1109,7 +1109,7 @@ msgstr "Powrót na Stronę Podcastów"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Odcinki"
 
@@ -1199,8 +1199,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 "Możesz znaleźć dodatkowe informacje na <a href=\"%(advertise-url)s\">stronie "
 "reklamowej</a>."
@@ -1221,8 +1221,8 @@ msgstr ""
 #| "podcast listed on %(sitename)s, feel free to apply by sending a mail "
 #| "with\n"
 #| "  <ul>\n"
-#| "   <li>your username on %(sitename)s (<a href=\"%(register-url)s"
-#| "\">register if you don't have one</a>)</li>\n"
+#| "   <li>your username on %(sitename)s (<a "
+#| "href=\"%(register-url)s\">register if you don't have one</a>)</li>\n"
 #| "   <li>the name and URL of the podcast you are publishing</li>\n"
 #| "   <li>an email address that is visible somewhere on the podcast's "
 #| "website (to legitimate you)\n"
@@ -1243,8 +1243,9 @@ msgstr ""
 "Strony publikujących są obecnie w wersji Beta, ale jeśli publikujesz podcast "
 "wymieniony na %(sitename)s, możesz aplikować wysyłając maila ze\n"
 " <ul>\n"
-" <li>swoją nazwą użytkownika na %(sitename)s (<a href=\"%(register-url)s"
-"\">zarejestruj się jeśli nie posiadasz takiej</a>)</li>\n"
+" <li>swoją nazwą użytkownika na %(sitename)s (<a "
+"href=\"%(register-url)s\">zarejestruj się jeśli nie posiadasz takiej</a>)</"
+"li>\n"
 " <li>nazwa i URL podcastu, który publikujesz</li>\n"
 " <li>adres e-mail, który jest widoczny gdzieś na stronie podcastu (w celu "
 "weryfikacji)\n"
@@ -1257,8 +1258,8 @@ msgid ""
 "If you already are registered as a publisher, please <a href=\"%(login-url)s?"
 "next=/publisher/\">login</a>."
 msgstr ""
-"Jeśli jesteś już zarejestrowany jako publikujący, proszę <a href="
-"\"%(login-url)s?next=/publisher/\">zaloguj się</a>."
+"Jeśli jesteś już zarejestrowany jako publikujący, proszę <a "
+"href=\"%(login-url)s?next=/publisher/\">zaloguj się</a>."
 
 #: mygpo/publisher/templates/publisher/info.html:41
 #, python-format
@@ -1315,8 +1316,8 @@ msgstr ""
 msgid "Update now"
 msgstr "Zaktualizuj z kanału"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr "Twitter"
 
@@ -1371,8 +1372,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1392,23 +1393,23 @@ msgstr "Link do"
 msgid "Show Group Stats"
 msgstr "Pokaż Grupowe Statystyki"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 #, fuzzy
 msgid "Data updated"
 msgstr "Lista urządzeń"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 #, fuzzy
 msgid "Publisher token updated"
 msgstr "Subskrypcja tego podcastu"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1485,8 +1486,8 @@ msgstr "Gdzie"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Subskrypcje"
 
@@ -1502,7 +1503,7 @@ msgid "User Page"
 msgstr "Strona użytkownika"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Ustawienia"
 
@@ -1626,13 +1627,13 @@ msgstr "%(listener_count)s słuchaczy"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
-"Nie masz jeszcze żadnych subskrybcji. Ustaw swoje <a href=\"%(devices)s"
-"\">klienty podcastów</a> i <a href=\"%(directory)s\">odkryj interesujące "
-"podcasty</a>."
+"Nie masz jeszcze żadnych subskrybcji. Ustaw swoje <a "
+"href=\"%(devices)s\">klienty podcastów</a> i <a "
+"href=\"%(directory)s\">odkryj interesujące podcasty</a>."
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
 #: mygpo/suggestions/templates/suggestions.html:54
@@ -1641,22 +1642,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr "Twoje subskrypcje"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, fuzzy, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "Twoje subskrypcje"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr "Ostatnie zmiany dla subskrybcji podcastów %(username)s na %(site)s"
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, fuzzy, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "Zasubkrybuj %(podcasttitle)s"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, fuzzy, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "Zasubkrybuj %(podcasttitle)s"
@@ -1675,27 +1676,27 @@ msgstr "Brak zainteresowania"
 msgid "No Suggestions Yet"
 msgstr "Sugestie"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Komputer stacjonarny"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Laptop"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Telefon komórkowy"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Serwer"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Inne"
 
@@ -1738,9 +1739,9 @@ msgid "You are already registered."
 msgstr "Jesteś już zarejestrowany"
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Zarejestruj się"
 
@@ -1829,57 +1830,69 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr "Nowe subskrybcje będą domyślnie prywatne."
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 #, fuzzy
 msgid "Your user has been activated. You can log in now."
 msgstr "Konto zostało aktywowane. Zapraszamy do my.gpodder.org"
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "Użytkownik nie istnieje"
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your settings have been saved."
+msgid "Your data has been archived."
+msgstr "Ustawienia zostały zapisane."
+
+#: mygpo/users/views/registration.py:221
 #, fuzzy
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "Konto zostało aktywowane. Zapraszamy do my.gpodder.org"
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 "Oops! Coś poszło nie tak. Proszę sprawdź ponownie dane, które wprowadziłeś."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 #, fuzzy
 msgid "Your account has been disconnected"
 msgstr "Ten odcinek został usunięty"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 #, fuzzy
 msgid "Username missing"
 msgstr "Nazwa użytkownika"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 #, fuzzy
 msgid "Password missing"
 msgstr "Reset hasła"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Nieprawidłowa nazwa użytkownika lub hasło"
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 #, fuzzy
 #| msgid "Please activate your account first."
 msgid ""
@@ -1887,80 +1900,59 @@ msgid ""
 "email"
 msgstr "Proszę zaktywuj najpierw swoje konto"
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-#, fuzzy
-msgid "Login failed."
-msgstr "Zaloguj się"
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 #, fuzzy
 msgid "E-Mail address"
 msgstr "Twój adres e-mail"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Obecne hasło"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Nowe hasło"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "Potwierdź hasło"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Nazwa"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Typ"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 #, fuzzy
 msgid "Device ID"
 msgstr "Urządzenie"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 #, fuzzy
 #| msgid "Device"
 msgid "ID on device"
 msgstr "Urządzenie"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "Podziel się tą subskrypcją z innymi użytkownikami (publiczne)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Nie wybrano żadnego urządzenia"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Proszę wprowadź swoją nazwę użytkownika"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "lub adres e-mail użyty podczas rejestracji"
 
@@ -2005,113 +1997,100 @@ msgstr ""
 msgid "Disconnect"
 msgstr "Odkryj"
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 #, fuzzy
 msgid "Account"
 msgstr "Utwórz konto użytkownika"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Zaloguj się"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr "Odkryj"
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 #, fuzzy
 msgid "Directory"
 msgstr "Historia"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr "Wesprzyj"
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr "Dokumenty"
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr "Mailing&nbsp;List"
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 #, fuzzy
 msgid "Questions"
 msgstr "Sugestie"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr "Wsparcie&nbsp;Us"
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr "Wesprzyj"
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr "Śledź"
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr "Blog"
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr "Blog&nbsp;(RSS)"
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr "Rozwijaj"
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr "API"
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "Biblioteki"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr "Klienty"
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr "Publikuj"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr "Uzyskaj&nbsp;dostęp"
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr "Linkuj&nbsp;do&nbsp;nas"
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr "Kontrybuuj"
 
@@ -2136,28 +2115,26 @@ msgstr "Praca"
 #| "If you want to contribute to gpodder.net by writing code, check out the "
 #| "<a href=\"/developer/\">Development</a> page. We also appreciate "
 #| "contributions of non-coding work, such as web and interface design, "
-#| "server operations, testing, etc. If you are interested, join the <a href="
-#| "\"http://wiki.gpodder.org/wiki/Mailing_List\">mailing list</a> or the IRC "
-#| "channel #gpodder on chat.freenode.net."
+#| "server operations, testing, etc. If you are interested, join the <a "
+#| "href=\"http://wiki.gpodder.org/wiki/Mailing_List\">mailing list</a> or "
+#| "the IRC channel #gpodder on chat.freenode.net."
 msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 "Jeśli chcesz wnieść wkład do gpodder.net przez pisanie kodu, sprawdź stronę "
 "<a href=\"/developer/\">Rozwój</a>. Doceniamy również wkład w postaci pracy "
 "nie programistycznej, takiej jak projektowanie interfejsu, operacje "
-"serwerowe, testowanie itd. Jeśli jesteś zainteresowany, dołącz do <a href="
-"\"https://gpodder.github.io/docs/mailing-list.html\">listy mailingowej</a> "
-"lub kanału IRC #gpodder na chat.freenode.net."
+"serwerowe, testowanie itd. Jeśli jesteś zainteresowany, dołącz do <a "
+"href=\"https://gpodder.github.io/docs/mailing-list.html\">listy mailingowej</"
+"a> lub kanału IRC #gpodder na chat.freenode.net."
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2191,7 +2168,7 @@ msgstr "Tak"
 msgid "No"
 msgstr "Nie"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "Przegląd"
 
@@ -2208,26 +2185,30 @@ msgstr "Najnowszy odcinek"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 "Witaj na %(site)s! Jeśli to Twoja pierwsza wizyta, to powinieneś ustawić "
-"swojego <a href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients."
-"html\">klienta podcastów</a> i spróbować zaznaczyć jak najwięcej możesz pól "
-"<em>Odkryj</em>."
+"swojego <a href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">klienta podcastów</a> i spróbować zaznaczyć jak najwięcej "
+"możesz pól <em>Odkryj</em>."
 
 #: mygpo/web/templates/dashboard.html:44
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
+#| "ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-"
+#| "list.html\">mailing list</a> or <a href=\"https://github.com/gpodder/"
+#| "mygpo/issues\">forum</a>."
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 "Jeśli masz problemy zajrzyj na <a href=\"%(help)s\">dokumentację</a> lub "
-"zadaj pytania na <a href=\"https://gpodder.github.io/docs/mailing-list.html"
-"\">liście mailingowej</a> lub <a href=\"https://getsatisfaction.com/"
+"zadaj pytania na <a href=\"https://gpodder.github.io/docs/mailing-"
+"list.html\">liście mailingowej</a> lub <a href=\"https://getsatisfaction.com/"
 "gpoddernet\">forum</a>."
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2331,7 +2312,7 @@ msgid "Thanks"
 msgstr "Dzięki"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr "Rozwój"
 
@@ -2345,8 +2326,9 @@ msgstr "Podcasty"
 #| msgid ""
 #| "The sourcecode of the webservice gpodder.net is released as open source "
 #| "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted "
-#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://bugs.gpodder."
-#| "org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</a>."
+#| "at GitHub</a>. Bugs can be reported at the <a href=\"https://"
+#| "bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">gPodder Bugtracker</"
+#| "a>."
 msgid ""
 "The sourcecode of the webservice gpodder.net is released as open source "
 "under the AGPLv3 and <a href=\"https://github.com/gpodder/mygpo\">hosted at "
@@ -2354,10 +2336,10 @@ msgid ""
 "gpodder/issues\">gPodder Issue Tracker on GitHub</a>."
 msgstr ""
 "Kod źródłowy serwisu internetowego gpodder.net jest udostępniony jako open "
-"source na licencji AGPLv3 i <a href=\"https://github.com/gpodder/mygpo"
-"\">hostowany na GitHubie</a>. Błędy mogą być zgłaszane na <a href=\"https://"
-"bugs.gpodder.org/enter_bug.cgi?product=gpodder.net\">bugtrackerze gPoddera</"
-"a>."
+"source na licencji AGPLv3 i <a href=\"https://github.com/gpodder/"
+"mygpo\">hostowany na GitHubie</a>. Błędy mogą być zgłaszane na <a "
+"href=\"https://bugs.gpodder.org/enter_bug.cgi?"
+"product=gpodder.net\">bugtrackerze gPoddera</a>."
 
 #: mygpo/web/templates/developer.html:21
 msgid "Integrating Clients"
@@ -2478,13 +2460,13 @@ msgstr "Zsynchronizuj"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
-"Nie masz jeszcze żadnych urządzeń. Idź do strony <a href=\"http://wiki."
-"gpodder.org/wiki/Web_Services/Clients\">klientów</a> by dowiedzieć się jak "
-"ustawić Twoje aplikacje klienckie."
+"Nie masz jeszcze żadnych urządzeń. Idź do strony <a href=\"http://"
+"wiki.gpodder.org/wiki/Web_Services/Clients\">klientów</a> by dowiedzieć się "
+"jak ustawić Twoje aplikacje klienckie."
 
 #: mygpo/web/templates/devicelist.html:74
 #, fuzzy
@@ -2501,7 +2483,7 @@ msgid "Delete Permanently"
 msgstr "Utwórz konto użytkownika"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 #, fuzzy
 msgid "Favorite Episodes"
 msgstr "Najnowszy odcinek"
@@ -2529,18 +2511,18 @@ msgstr ""
 "przeciągu kilku minut. Poczekaj trochę i spróbuj raz jeszcze!"
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "Moje Tagi"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"Nie otagowałes jeszcze żadnych podcastów. Idź do swoich <a href="
-"\"%(subscriptions-url)s\">subskrypcji</a> i otaguj jakieś."
+"Nie otagowałes jeszcze żadnych podcastów. Idź do swoich <a "
+"href=\"%(subscriptions-url)s\">subskrypcji</a> i otaguj jakieś."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2554,11 +2536,11 @@ msgstr "Ten odcinek został usunięty"
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
-"Powinieneś otrzymać mail ze swoim nowym hasłem. Proszę <a href="
-"\"%(login-url)s\">zaloguj się</a> teraz."
+"Powinieneś otrzymać mail ze swoim nowym hasłem. Proszę <a "
+"href=\"%(login-url)s\">zaloguj się</a> teraz."
 
 #: mygpo/web/templates/password_reset_failed.html:4
 msgid "Password could not be reset"
@@ -2620,7 +2602,7 @@ msgstr "Subskrypcje"
 msgid "Make Public"
 msgstr "Zrób publiczne"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 #, fuzzy
 msgid "Privacy Policy"
 msgstr "Ustawienia"
@@ -2669,6 +2651,17 @@ msgstr ""
 "Nazwy są wyświetlane po pobraniu informacji ze źródła, a to może chwilę "
 "potrwać. Podcast będzie miał taką nazwę dopóki ten proces nie zostanie "
 "ukończony."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Reactivate"
+msgid "Archived User"
+msgstr "Reaktywuj"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2834,49 +2827,53 @@ msgstr "Ten odcinek został usunięty"
 msgid "Unknown Episode"
 msgstr "Dlaczego odcinek bez nazwy?"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Strona domowa"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Pomoc"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 #, fuzzy
 msgid "User subscriptions"
 msgstr "Twoje subskrypcje"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Sugestie"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 #, fuzzy
 msgid "Toplists"
 msgstr "Lista najlepszych"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Urządzenia"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr "Społecznośc"
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr "Moja strona użytkownika"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Prywatność"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "Link do gpodder.net"
 
@@ -2891,52 +2888,73 @@ msgstr "{h}h {m}m {s}s"
 msgid "{m}m {s}s"
 msgstr "{h}h {m}m {s}s"
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "inna strona"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "Rozpocznij swoją reklamę"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "Skontaktuj się z <a "
+#~ "href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> jeśli chciałbyś "
+#~ "reklamować się na %(sitename)s lub jeżeli masz jakieś pytania. Płatności "
+#~ "są dokonywane przez PayPal do thp@perli.net."
+
+#, fuzzy
+#~ msgid "Login failed."
+#~ msgstr "Zaloguj się"
+
+#~ msgid "Mailing&nbsp;List"
+#~ msgstr "Mailing&nbsp;List"
 
 #, fuzzy
 #~| msgid ""
 #~| "If you want to support gpodder.net financially, you can donate via "
 #~| "PayPal to stefan@skoegl.net. You can also send a book via Amazon (<a "
-#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href="
-#~| "\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://www."
-#~| "amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
+#~| "href=\"http://www.amazon.de/wishlist/24H4ORJ0Z0JBH\">DE</a>, <a "
+#~| "href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</a> or <a href=\"http://"
+#~| "www.amazon.co.uk/registry/wishlist/24JRVURXUKO6F\">UK</a>)."
 #~ msgid ""
 #~ "If you want to support gpodder.net financially, you can donate via <a "
 #~ "href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>. You can also "
-#~ "send a book via Amazon (<a href=\"http://www.amazon.de/"
-#~ "wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R"
-#~ "\">US</a> or <a href=\"http://www.amazon.co.uk/registry/"
-#~ "wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "send a book via Amazon (<a href=\"http://www.amazon.de/wishlist/"
+#~ "24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</"
+#~ "a> or <a href=\"http://www.amazon.co.uk/registry/wishlist/"
+#~ "24JRVURXUKO6F\">UK</a>)."
 #~ msgstr ""
 #~ "Jeśli chcesz wspierać gpodder.net finansowo, to możesz przekazać "
 #~ "darowiznę przez PayPal do stefan@skoegl.net. Możesz również wysłać "
-#~ "książkę przez Amazon (<a href=\"http://www.amazon.de/"
-#~ "wishlist/24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R"
-#~ "\">US</a> lub <a href=\"http://www.amazon.co.uk/registry/"
-#~ "wishlist/24JRVURXUKO6F\">UK</a>)."
+#~ "książkę przez Amazon (<a href=\"http://www.amazon.de/wishlist/"
+#~ "24H4ORJ0Z0JBH\">DE</a>, <a href=\"http://amzn.com/w/3IPIF4J4F2C5R\">US</"
+#~ "a> lub <a href=\"http://www.amazon.co.uk/registry/wishlist/"
+#~ "24JRVURXUKO6F\">UK</a>)."
 
 #, fuzzy
 #~ msgid "Last update:"
@@ -3119,8 +3137,8 @@ msgstr "inna strona"
 #~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> with the <a "
 #~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
 #~ msgstr ""
-#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> z <a href="
-#~ "\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
+#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> z <a "
+#~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
 
 #~ msgid "Nokia Podcasting on Symbian devices"
 #~ msgstr "Nokia Podcasting dla urządzeń z Symbianem"
@@ -3158,11 +3176,11 @@ msgstr "inna strona"
 #~ "synchronizować urządzeń używając tego samego ID urządzenia.</strong>"
 
 #~ msgid ""
-#~ "A list of your devices can be found on the <a href=\"%(devices-url)s"
-#~ "\">devices page</a>."
+#~ "A list of your devices can be found on the <a href=\"%(devices-"
+#~ "url)s\">devices page</a>."
 #~ msgstr ""
-#~ "Lista Twoich urządzeń może być znaleziona na <a href=\"%(devices-url)s"
-#~ "\">stronie urządzeń</a>."
+#~ "Lista Twoich urządzeń może być znaleziona na <a href=\"%(devices-"
+#~ "url)s\">stronie urządzeń</a>."
 
 #, fuzzy
 #~ msgid "Synchronizing Devices"
@@ -3202,22 +3220,22 @@ msgstr "inna strona"
 #~ "na wszystkich urządzeniach. "
 
 #~ msgid ""
-#~ "By default we include information about your subscriptions in our <a href="
-#~ "\"%(toplist-url)s\">toplist</a> and <a href=\"%(suggestions-url)s"
-#~ "\">podcast suggestions</a>. <strong>We will never associate your username "
-#~ "and/or email address with your subscriptions on public pages.</strong> "
-#~ "You can even opt-out from our anonymized statistics at the <a href="
-#~ "\"%(privacy-url)s\">privacy page</a>. If you mark some podcasts as "
+#~ "By default we include information about your subscriptions in our <a "
+#~ "href=\"%(toplist-url)s\">toplist</a> and <a href=\"%(suggestions-"
+#~ "url)s\">podcast suggestions</a>. <strong>We will never associate your "
+#~ "username and/or email address with your subscriptions on public pages.</"
+#~ "strong> You can even opt-out from our anonymized statistics at the <a "
+#~ "href=\"%(privacy-url)s\">privacy page</a>. If you mark some podcasts as "
 #~ "private, they will also not show up in your sharable subscription list."
 #~ msgstr ""
-#~ "Domyślnie dołączamy informacje o Twoich subskrypcjach w naszej <a href="
-#~ "\"%(toplist-url)s\">topliście</a> i <a href=\"%(suggestions-url)s"
-#~ "\">sugestiach podcastów</a>. <strong>Nigdy nie powiążemy Twojej nazwy "
-#~ "użytkownika i/lub adresu e-mail z Twoim subskrypcjami na publicznych "
-#~ "stronach.</strong> Możesz nawet wypisać się z naszym anonimizowanych "
-#~ "statystyk na <a href=\"%(privacy-url)s\">stronie prywatności</a>. Jeśli "
-#~ "zaznaczysz jakieś swoje podcasty jako prywatne, wtedy nie pojawią się na "
-#~ "współdzielonej liście subskrybcji."
+#~ "Domyślnie dołączamy informacje o Twoich subskrypcjach w naszej <a href=\"%"
+#~ "(toplist-url)s\">topliście</a> i <a href=\"%(suggestions-"
+#~ "url)s\">sugestiach podcastów</a>. <strong>Nigdy nie powiążemy Twojej "
+#~ "nazwy użytkownika i/lub adresu e-mail z Twoim subskrypcjami na "
+#~ "publicznych stronach.</strong> Możesz nawet wypisać się z naszym "
+#~ "anonimizowanych statystyk na <a href=\"%(privacy-url)s\">stronie "
+#~ "prywatności</a>. Jeśli zaznaczysz jakieś swoje podcasty jako prywatne, "
+#~ "wtedy nie pojawią się na współdzielonej liście subskrybcji."
 
 #, fuzzy
 #~ msgid "Sharing your Subscriptions"
@@ -3247,13 +3265,13 @@ msgstr "inna strona"
 #~ msgstr "Zmień na publiczne"
 
 #~ msgid ""
-#~ "Browse the <a href=\"%(toplist-url)s\">toplist</a> and your <a href="
-#~ "\"%(suggestions-url)s\">personal suggestions</a>, <a href=\"%(search-url)s"
-#~ "\">search</a> or paste the URL of the podcast's feed here"
+#~ "Browse the <a href=\"%(toplist-url)s\">toplist</a> and your <a href=\"%"
+#~ "(suggestions-url)s\">personal suggestions</a>, <a href=\"%(search-"
+#~ "url)s\">search</a> or paste the URL of the podcast's feed here"
 #~ msgstr ""
-#~ "Przeglądaj <a href=\"%(toplist-url)s\">toplistę</a> I Twoje <a href="
-#~ "\"%(suggestions-url)s\">osobiste sugestie</a>, <a href=\"%(search-url)s"
-#~ "\">szukaj</a> lub wklejaj adresy URL kanałów podcastów tutaj"
+#~ "Przeglądaj <a href=\"%(toplist-url)s\">toplistę</a> I Twoje <a href=\"%"
+#~ "(suggestions-url)s\">osobiste sugestie</a>, <a href=\"%(search-"
+#~ "url)s\">szukaj</a> lub wklejaj adresy URL kanałów podcastów tutaj"
 
 #~ msgid "Account activated"
 #~ msgstr "Konto aktywne"
@@ -3272,11 +3290,11 @@ msgstr "inna strona"
 #~ msgstr "Zresetuj hasło dla swojego konta na %s"
 
 #~ msgid ""
-#~ "Here is your new password for your account %(username)s on %(site)s: "
-#~ "%(password)s"
+#~ "Here is your new password for your account %(username)s on %(site)s: %"
+#~ "(password)s"
 #~ msgstr ""
-#~ "Tutaj jest Twoje nowe hasło dla Twojego konta  %(username)s na %(site)s: "
-#~ "%(password)s"
+#~ "Tutaj jest Twoje nowe hasło dla Twojego konta  %(username)s na %(site)s: %"
+#~ "(password)s"
 
 #~ msgid "Invalid Username entered"
 #~ msgstr "Wprowadzono nieprawidłową nazwę użytkownika"
@@ -3313,8 +3331,8 @@ msgstr "inna strona"
 #~ msgstr "Subskrypcja tego podcastu"
 
 #~ msgid ""
-#~ "If you're new here, you should start by reading our <a href=\"%(help-url)s"
-#~ "\">introduction</a>."
+#~ "If you're new here, you should start by reading our <a href=\"%(help-"
+#~ "url)s\">introduction</a>."
 #~ msgstr ""
 #~ "Jeśli jesteś tutaj nowy, powinieneś zacząć od przeczytania naszego <a "
 #~ "href=\"%(help-url)s\">wprowadzenia</a>."
@@ -3344,9 +3362,6 @@ msgstr "inna strona"
 #~ msgstr ""
 #~ "Wystąpił błąd podczas przetwarzania żądania. Do deweloperów został "
 #~ "wysłany e-mail z opisem błędu."
-
-#~ msgid "Your settings have been saved."
-#~ msgstr "Ustawienia zostały zapisane."
 
 #, fuzzy
 #~ msgid "Update account settings"
@@ -3683,8 +3698,8 @@ msgstr "inna strona"
 #~ "Below the field &quot;Devices&quot; you see the link &quot;Subscribe "
 #~ "to ... on other devices&quot; click on it."
 #~ msgstr ""
-#~ "Poniżej pola &quot;Urządzenia&quot; znajduje się odnośnik &quot;"
-#~ "Zasubkrybuj ... w innych urządzeniach&quot;, kliknij go."
+#~ "Poniżej pola &quot;Urządzenia&quot; znajduje się odnośnik "
+#~ "&quot;Zasubkrybuj ... w innych urządzeniach&quot;, kliknij go."
 
 #~ msgid ""
 #~ "On the next page you can choose your desired device on which you want to "

--- a/mygpo/locale/pt/LC_MESSAGES/django.po
+++ b/mygpo/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gpodder.net\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2010-06-17 17:01-0000\n"
 "Last-Translator: Sérgio Marques <smarquespt@gmail.com>\n"
 "Language-Team: PT\n"
@@ -29,7 +29,7 @@ msgstr "Activar Novamente"
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Nome de utilizador"
 
@@ -162,7 +162,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 #, fuzzy
 #| msgid "Publisher Pages"
 msgid "Publisher Permissions"
@@ -203,7 +203,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr "Podcast/Episódio"
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -298,26 +302,36 @@ msgstr ""
 msgid "User-Agent"
 msgstr ""
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr ""
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 #, fuzzy
 msgid "No user found"
 msgstr "Não encontrado"
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -400,8 +414,8 @@ msgstr "Directório de Podcasts"
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
 
 #: mygpo/directory/templates/directory.html:46
@@ -466,8 +480,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr "Podcast"
 
@@ -491,14 +505,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 #, fuzzy
 msgid "Podcasts"
 msgstr "Podcast"
@@ -547,7 +561,7 @@ msgid "OK"
 msgstr "OK"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 #, fuzzy
 msgid "Missing Podcast"
 msgstr "Podcasts Sugeridos"
@@ -581,7 +595,7 @@ msgstr "Podcasts Sugeridos"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 #, fuzzy
 msgid "Podcast Lists"
 msgstr "Os Melhores Podcasts"
@@ -600,6 +614,7 @@ msgstr "Nome de utilizador"
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 #, fuzzy
 msgid "Download"
 msgstr "Transferido"
@@ -619,8 +634,8 @@ msgstr ""
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Pesquisar"
 
@@ -654,20 +669,20 @@ msgstr "Os Melhores"
 msgid "Client Access"
 msgstr ""
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, fuzzy, python-format
 msgid "%d podcasts added"
 msgstr "podcasts"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Histórico"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 #, fuzzy
@@ -690,7 +705,7 @@ msgid "Action"
 msgstr "Acção"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Dispositivo"
 
@@ -700,7 +715,7 @@ msgstr "Adicionar"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 #, fuzzy
 msgid "Subscription History"
@@ -736,7 +751,7 @@ msgstr "Não"
 msgid "Earlier"
 msgstr ""
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -819,16 +834,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr "%(username)s ainda não tem quaisquer subscrições."
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -872,24 +887,24 @@ msgstr "Favorito"
 msgid "Episode History"
 msgstr "Os Melhores Episódios"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr "Podcasts Sem Nome"
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 #, fuzzy
 msgid "subscribers"
@@ -963,9 +978,9 @@ msgstr "Alter o campo 'SEU_ENDEREÇO'  com o endereço do seu podcast."
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr "Publicitar"
 
@@ -1033,21 +1048,6 @@ msgid ""
 "advertisement period."
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr "Inicie a sua publicidade"
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-"Contacte <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> se "
-"quiser publicitar o seu podcast no %(sitename)s ou se tiver questões. Os "
-"pagamentos são feitos via paypal para thp@perli.net."
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr "Episódio Sem Nome"
@@ -1070,7 +1070,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1090,7 +1090,7 @@ msgstr "Voltar à Página de Podcasts"
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr "Episódios"
 
@@ -1184,8 +1184,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 "Pode obter mais detalhes <a href=\"%(advertise-url)s\">nesta página</a>."
 
@@ -1274,8 +1274,8 @@ msgstr ""
 msgid "Update now"
 msgstr "Actualizar da Fonte"
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1330,8 +1330,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1351,23 +1351,23 @@ msgstr "Ligação a"
 msgid "Show Group Stats"
 msgstr "Mostrar Estatísticas do Grupo"
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 #, fuzzy
 msgid "Data updated"
 msgstr "Lista de Dispositivos"
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 #, fuzzy
 msgid "Publisher token updated"
 msgstr "Descobrir Podcasts"
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1448,8 +1448,8 @@ msgstr "Partilhando"
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr "Subscriçoes"
 
@@ -1466,7 +1466,7 @@ msgid "User Page"
 msgstr "Nome de utilizador"
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Definições"
 
@@ -1589,9 +1589,9 @@ msgstr "%(listener_count)s ouvintes"
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1601,22 +1601,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr "Transferido"
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, fuzzy, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr "Subscrições de %(username)s's"
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, fuzzy, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr "Subscrever %(podcasttitle)s"
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, fuzzy, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr "Subscrever %(podcasttitle)s"
@@ -1635,27 +1635,27 @@ msgstr ""
 msgid "No Suggestions Yet"
 msgstr "Sugestões"
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr "Computador"
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr "Portátil"
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr "Telenóvel"
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Servidor"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Outro"
 
@@ -1695,9 +1695,9 @@ msgid "You are already registered."
 msgstr "Você já está registado."
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Registar"
 
@@ -1783,57 +1783,69 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 #, fuzzy
 #| msgid "Your account already has been activated. Go ahead and log in."
 msgid "Your user has been activated. You can log in now."
 msgstr "A sua conta já está activa. Pode inicar a sessão."
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr "Utilizador não existe."
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+#, fuzzy
+#| msgid "Your settings have been saved."
+msgid "Your data has been archived."
+msgstr "As suas definições foram gravadas."
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr "A sua conta já está activa. Pode inicar a sessão."
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 "Oops! Ocorreu um erro. Não se esqueça de verificar os dados introduzidos."
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 #, fuzzy
 msgid "Your account has been disconnected"
 msgstr "A sua conta foi apagada"
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 #, fuzzy
 msgid "Username missing"
 msgstr "Nome de utilizador"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 #, fuzzy
 msgid "Password missing"
 msgstr "Reposição de Palavra-passe"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Utilizador ou palavra-passe inválido(a)"
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 #, fuzzy
 #| msgid "Please activate your account first."
 msgid ""
@@ -1841,78 +1853,57 @@ msgid ""
 "email"
 msgstr "Por favor, active primeiro a sua conta."
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-#, fuzzy
-msgid "Login failed."
-msgstr "Inicie aqui a sessão"
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "Endereço de E-mail"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Palavra-passe actual"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Nova palavra-passe"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr "Confirmar palavra-passe"
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Nome"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Tipo"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "ID do Dispositivo"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 #, fuzzy
 #| msgid "Device"
 msgid "ID on device"
 msgstr "Dispositivo"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr "Partilhar esta subscrição com outros utilizadores (público)"
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Nenhum dispositivo seleccionado"
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Por favor, indique o nome de utilizador"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr "ou o endereço de e-mail indicado no registo"
 
@@ -1955,112 +1946,99 @@ msgstr ""
 msgid "Disconnect"
 msgstr ""
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "Conta"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Iniciar sessão"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr ""
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr "Directório"
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 #, fuzzy
 msgid "Questions"
 msgstr "Sugestões"
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr "Bibliotecas"
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 #, fuzzy
 msgid "Publish"
 msgstr "Publicador"
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -2085,15 +2063,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -2124,7 +2100,7 @@ msgstr "Sim"
 msgid "No"
 msgstr "Não"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr "Visão geral"
 
@@ -2140,18 +2116,17 @@ msgstr "Episódios Recentes"
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2249,7 +2224,7 @@ msgid "Thanks"
 msgstr "Obrigado"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2378,9 +2353,9 @@ msgstr "Sincronizado"
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2397,7 +2372,7 @@ msgid "Delete Permanently"
 msgstr "Apagar conta"
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr "Episódios Favoritos"
 
@@ -2422,18 +2397,18 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "As minhas marcações"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
-"Ainda não marcour quaisquer podcasts. Aceda às <a href="
-"\"%(subscriptions-url)s\">subscrições</a> e marque algum."
+"Ainda não marcour quaisquer podcasts. Aceda às <a "
+"href=\"%(subscriptions-url)s\">subscrições</a> e marque algum."
 
 #: mygpo/web/templates/password_reset.html:4
 msgid "Password reset"
@@ -2446,11 +2421,11 @@ msgstr "A sua palavra-passe foi reposta"
 #: mygpo/web/templates/password_reset.html:13
 #, fuzzy, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
-"Deve ter recebido uma mensagem com a nova palavra-passe. Por favor, <a href="
-"\"/login\">inicie</a> agora a sessão."
+"Deve ter recebido uma mensagem com a nova palavra-passe. Por favor, <a "
+"href=\"/login\">inicie</a> agora a sessão."
 
 #: mygpo/web/templates/password_reset_failed.html:4
 msgid "Password could not be reset"
@@ -2511,7 +2486,7 @@ msgstr "Subscriçoes"
 msgid "Make Public"
 msgstr "Marcar como público"
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 #, fuzzy
 msgid "Privacy Policy"
 msgstr "Privacidade"
@@ -2561,6 +2536,17 @@ msgstr ""
 "Porque nós mostramos os nomes após obter as informações da fonte, e isto "
 "pode levar algum tempo. Até que esta fase esteja concluída, o podcast será "
 "invocado desta forma."
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+#, fuzzy
+#| msgid "Reactivate"
+msgid "Archived User"
+msgstr "Activar Novamente"
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
+msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
 #: mygpo/web/templates/user_subscriptions.html:18
@@ -2717,49 +2703,53 @@ msgstr "Este episódio foi apagado"
 msgid "Unknown Episode"
 msgstr "Episódio Sem Nome"
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr "Início"
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Ajuda"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr "Subscrições do utilizador"
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr "Sugestões"
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 #, fuzzy
 msgid "Toplists"
 msgstr "Os Melhores"
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Dispositivos"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 #, fuzzy
 msgid "My Userpage"
 msgstr "Nome de utilizador"
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Privacidade"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr "Ligação para gpodder.net"
 
@@ -2773,30 +2763,47 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr "outo sítio"
+
+#~ msgid "Start your Advertisement"
+#~ msgstr "Inicie a sua publicidade"
+
+#, python-format
+#~ msgid ""
+#~ "Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if "
+#~ "you would like to advertise on %(sitename)s or if you have any questions. "
+#~ "Payments are done via PayPal to thp@perli.net."
+#~ msgstr ""
+#~ "Contacte <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> se "
+#~ "quiser publicitar o seu podcast no %(sitename)s ou se tiver questões. Os "
+#~ "pagamentos são feitos via paypal para thp@perli.net."
+
+#, fuzzy
+#~ msgid "Login failed."
+#~ msgstr "Inicie aqui a sessão"
 
 #, fuzzy
 #~ msgid "Last update:"
@@ -2950,16 +2957,16 @@ msgstr "outo sítio"
 #~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> with the <a "
 #~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
 #~ msgstr ""
-#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> com <a href="
-#~ "\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
+#~ "<a href=\"http://lincgeek.org/bashpodder/\">BashPodder</a> com <a "
+#~ "href=\"http://thpinfo.com/2010/mygpoclient/\">mygpoclient</a>"
 
 #~ msgid "Nokia Podcasting on Symbian devices"
 #~ msgstr "Nokia Podcasting nos dispositivos Symbian"
 
 #, fuzzy
 #~ msgid ""
-#~ "A list of your devices can be found on the <a href=\"%(devices-url)s"
-#~ "\">devices page</a>."
+#~ "A list of your devices can be found on the <a href=\"%(devices-"
+#~ "url)s\">devices page</a>."
 #~ msgstr ""
 #~ "Uma lista de dispositivos pode ser encontrada na<a href=\"/devices/"
 #~ "\">página de dispositivos</a>."
@@ -3006,8 +3013,8 @@ msgstr "outo sítio"
 
 #, fuzzy
 #~ msgid ""
-#~ "Here is your new password for your account %(username)s on %(site)s: "
-#~ "%(password)s"
+#~ "Here is your new password for your account %(username)s on %(site)s: %"
+#~ "(password)s"
 #~ msgstr ""
 #~ "Aqui está a sua nova palavra-passe para a conta em %(site)s: %(password)s"
 
@@ -3044,8 +3051,8 @@ msgstr "outo sítio"
 
 #, fuzzy
 #~ msgid ""
-#~ "If you're new here, you should start by reading our <a href=\"%(help-url)s"
-#~ "\">introduction</a>."
+#~ "If you're new here, you should start by reading our <a href=\"%(help-"
+#~ "url)s\">introduction</a>."
 #~ msgstr ""
 #~ "Se ainda é principiante aqui deve ler a nossa <a href=\"/online-help/"
 #~ "\">introdução</a>."
@@ -3083,9 +3090,6 @@ msgstr "outo sítio"
 #~ "Ocorreu um erro ao processar o seu pedido. Foi enviado aos programadores, "
 #~ "uma mensagem com a descrição do erro."
 
-#~ msgid "Your settings have been saved."
-#~ msgstr "As suas definições foram gravadas."
-
 #~ msgid "Contact information and password"
 #~ msgstr "Informação de contacto e palavra-passe"
 
@@ -3115,9 +3119,9 @@ msgstr "outo sítio"
 
 #, fuzzy
 #~ msgid ""
-#~ "You have subscribed to <a href=\"%(subscriptions-url)s\">"
-#~ "%(subscription_count)s podcasts</a> on <a href=\"%(devices-url)s\">"
-#~ "%(device_count)s devices</a>. Now you can\n"
+#~ "You have subscribed to <a href=\"%(subscriptions-url)s\">%"
+#~ "(subscription_count)s podcasts</a> on <a href=\"%(devices-url)s\">%"
+#~ "(device_count)s devices</a>. Now you can\n"
 #~ "   <ul>\n"
 #~ "    <li><a href=\"%(share-url)s\">share your subscriptions with others</"
 #~ "a></li>\n"
@@ -3131,9 +3135,9 @@ msgstr "outo sítio"
 #~ "   </ul>"
 #~ msgstr ""
 #~ "\n"
-#~ "   Você fez a subscrição a <a href=\"/subscriptions/\">"
-#~ "%(subscription_count)s podcast(s)</a> no(s) <a href=\"/devices/\">"
-#~ "%(device_count)s dispositivo(s)</a>. Agora, já pode\n"
+#~ "   Você fez a subscrição a <a href=\"/subscriptions/\">%"
+#~ "(subscription_count)s podcast(s)</a> no(s) <a href=\"/devices/\">%"
+#~ "(device_count)s dispositivo(s)</a>. Agora, já pode\n"
 #~ "   <ul>\n"
 #~ "    <li><a href=\"/share/\">partilhar as subscrições com outros "
 #~ "utilizadores</a></li>\n"
@@ -3179,8 +3183,8 @@ msgstr "outo sítio"
 #~ "private."
 #~ msgstr ""
 #~ "Ainda não subscreveu este  podcast. Assim, os seus episódios estão "
-#~ "disponíveis a terceiros. Caso não o pretenda, <a href=\"/podcast/"
-#~ "%(podcast_id)s/subscribe\">subscreva este podcast</a> e marque-o como "
+#~ "disponíveis a terceiros. Caso não o pretenda, <a href=\"/podcast/%"
+#~ "(podcast_id)s/subscribe\">subscreva este podcast</a> e marque-o como "
 #~ "privado."
 
 #, fuzzy
@@ -3190,8 +3194,8 @@ msgstr "outo sítio"
 #~ "mark your subscription as private."
 #~ msgstr ""
 #~ "Os seus capítulos são mostrados a negrito. Se não quiser que os capítulos "
-#~ "estejam disponíveis a terceiros, vá até href=\"/podcast/%(podcast_id)s"
-#~ "\">podcast page</a> e assinale a subscrição como privada."
+#~ "estejam disponíveis a terceiros, vá até href=\"/podcast/%"
+#~ "(podcast_id)s\">podcast page</a> e assinale a subscrição como privada."
 
 #, fuzzy
 #~ msgid ""
@@ -3232,8 +3236,8 @@ msgstr "outo sítio"
 
 #, fuzzy
 #~ msgid ""
-#~ "or show <a href=\"%(episode-toplist-url)s?lang=&types=%(type_param)s"
-#~ "\">all languages</a>."
+#~ "or show <a href=\"%(episode-toplist-url)s?lang=&types=%"
+#~ "(type_param)s\">all languages</a>."
 #~ msgstr "ou mostrar <a href=\"/toplist?lang=\">todos os idiomas</a>."
 
 #~ msgid "You think that's not much?"
@@ -3252,8 +3256,8 @@ msgstr "outo sítio"
 #, fuzzy
 #~ msgid ""
 #~ "You can access a feed containing your favorites episodes at\n"
-#~ "     <strong><a href=\"%(favorites-feed-url)s\">http://%(domain)s"
-#~ "%(favorites-feed-url)s</a></strong>."
+#~ "     <strong><a href=\"%(favorites-feed-url)s\">http://%(domain)s%"
+#~ "(favorites-feed-url)s</a></strong>."
 #~ msgstr ""
 #~ "\n"
 #~ "     Pode aceder à fonte que contém os seus episódios favoritos em\n"

--- a/mygpo/locale/tr_TR/LC_MESSAGES/django.po
+++ b/mygpo/locale/tr_TR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gpodder.net\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-04 12:52+0000\n"
+"POT-Creation-Date: 2026-08-30 17:44+0000\n"
 "PO-Revision-Date: 2012-10-13 12:53+0000\n"
 "Last-Translator: zeugma <unknown@example.com>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/projects/p/mygpo/"
@@ -28,7 +28,7 @@ msgstr ""
 
 #: mygpo/administration/templates/admin/activate-user.html:20
 #: mygpo/administration/templates/admin/resend-acivation.html:20
-#: mygpo/web/forms.py:182 mygpo/web/templates/account.html:112
+#: mygpo/web/forms.py:180 mygpo/web/templates/account.html:110
 msgid "Username"
 msgstr "Kullanıcı adı"
 
@@ -156,7 +156,7 @@ msgstr ""
 #: mygpo/administration/templates/admin/make-publisher-input.html:12
 #: mygpo/administration/templates/admin/make-publisher-result.html:9
 #: mygpo/administration/templates/admin/make-publisher-result.html:12
-#: mygpo/administration/views.py:449
+#: mygpo/administration/views.py:462
 msgid "Publisher Permissions"
 msgstr ""
 
@@ -191,7 +191,11 @@ msgstr ""
 msgid "Merge Podcasts and Episodes"
 msgstr ""
 
-#: mygpo/administration/templates/admin/merge-grouping.html:24
+#: mygpo/administration/templates/admin/merge-grouping.html:25
+msgid "No need to merge: a single Podcast is returned"
+msgstr ""
+
+#: mygpo/administration/templates/admin/merge-grouping.html:29
 msgid ""
 "Episodes that have the same number will be merged. Please verify all your "
 "changes by clicking on 'Renew Groups' before starting the Merge."
@@ -279,25 +283,35 @@ msgstr ""
 msgid "User-Agent"
 msgstr ""
 
-#: mygpo/administration/views.py:154 mygpo/administration/views.py:172
+#: mygpo/administration/views.py:163 mygpo/administration/views.py:181
 #, python-brace-format
 msgid "No podcast with URL {url}"
 msgstr ""
 
-#: mygpo/administration/views.py:323 mygpo/administration/views.py:358
+#: mygpo/administration/views.py:331 mygpo/administration/views.py:366
 msgid "Provide either username or email address"
 msgstr ""
 
-#: mygpo/administration/views.py:329 mygpo/administration/views.py:364
+#: mygpo/administration/views.py:337 mygpo/administration/views.py:372
 msgid "No user found"
 msgstr ""
 
-#: mygpo/administration/views.py:336
+#: mygpo/administration/views.py:344
 #, python-brace-format
 msgid "User {username} ({email}) activated"
 msgstr ""
 
-#: mygpo/administration/views.py:375
+#: mygpo/administration/views.py:378
+#, python-brace-format
+msgid "User {username} is already activated"
+msgstr ""
+
+#: mygpo/administration/views.py:383
+#, python-brace-format
+msgid "User {username} data has been archived."
+msgstr ""
+
+#: mygpo/administration/views.py:389
 #, python-brace-format
 msgid "Email for {username} ({email}) resent"
 msgstr ""
@@ -379,8 +393,8 @@ msgstr ""
 #: mygpo/directory/templates/directory.html:30
 #, python-format
 msgid ""
-"%(listtitle)s <span class=\"by-user\">by <a href=\"%(user-lists-url)s\">"
-"%(username)s</a></span>"
+"%(listtitle)s <span class=\"by-user\">by <a "
+"href=\"%(user-lists-url)s\">%(username)s</a></span>"
 msgstr ""
 
 #: mygpo/directory/templates/directory.html:46
@@ -441,8 +455,8 @@ msgstr ""
 #: mygpo/directory/templates/directory/license-podcasts.html:36
 #: mygpo/directory/templates/search.html:35
 #: mygpo/directory/templates/toplist.html:26
-#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:37
-#: mygpo/web/templatetags/menu.py:78
+#: mygpo/podcastlists/templates/list.html:48 mygpo/web/templatetags/menu.py:39
+#: mygpo/web/templatetags/menu.py:80
 msgid "Podcast"
 msgstr ""
 
@@ -465,14 +479,14 @@ msgid "Podcasts with License Information"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:23
-#: mygpo/web/templatetags/menu.py:44
+#: mygpo/web/templatetags/menu.py:46
 msgid "License"
 msgstr ""
 
 #: mygpo/directory/templates/directory/licenses.html:24
 #: mygpo/directory/templates/podcast_lists.html:24
-#: mygpo/web/templates/base.html:135 mygpo/web/templates/home.html:155
-#: mygpo/web/templatetags/menu.py:46
+#: mygpo/web/templates/base.html:114 mygpo/web/templates/home.html:157
+#: mygpo/web/templatetags/menu.py:48
 msgid "Podcasts"
 msgstr ""
 
@@ -519,7 +533,7 @@ msgid "OK"
 msgstr "Tamam"
 
 #: mygpo/directory/templates/missing.html:11
-#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:39
+#: mygpo/directory/templates/missing.html:14 mygpo/web/templatetags/menu.py:41
 msgid "Missing Podcast"
 msgstr ""
 
@@ -552,7 +566,7 @@ msgstr "Bir podcast ekle"
 #: mygpo/podcastlists/templates/lists.html:13
 #: mygpo/podcastlists/templates/lists.html:16
 #: mygpo/podcastlists/templates/lists_user.html:9
-#: mygpo/web/templatetags/menu.py:40 mygpo/web/templatetags/menu.py:68
+#: mygpo/web/templatetags/menu.py:42 mygpo/web/templatetags/menu.py:70
 msgid "Podcast Lists"
 msgstr ""
 
@@ -568,6 +582,7 @@ msgstr ""
 #: mygpo/history/templates/episode-history.html:53
 #: mygpo/podcasts/templates/episode.html:53
 #: mygpo/publisher/templates/publisher/episode.html:35
+#: mygpo/web/templates/user_archived.html:60
 msgid "Download"
 msgstr ""
 
@@ -586,8 +601,8 @@ msgstr ""
 #: mygpo/directory/templates/search.html:25
 #: mygpo/podcastlists/templates/list.html:104
 #: mygpo/subscriptions/templates/subscriptions.html:53
-#: mygpo/web/templates/base.html:136 mygpo/web/templates/home.html:156
-#: mygpo/web/templatetags/menu.py:38
+#: mygpo/web/templates/base.html:115 mygpo/web/templates/home.html:158
+#: mygpo/web/templatetags/menu.py:40
 msgid "Search"
 msgstr "Arama"
 
@@ -619,20 +634,20 @@ msgstr ""
 msgid "Client Access"
 msgstr ""
 
-#: mygpo/directory/views.py:336
+#: mygpo/directory/views.py:334
 #, fuzzy, python-format
 msgid "%d podcasts added"
 msgstr "Bir podcast ekle"
 
 #: mygpo/history/templates/episode-history.html:47
 #: mygpo/history/templates/episode-history.html:81
-#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:58
+#: mygpo/web/templates/device.html:73 mygpo/web/templatetags/menu.py:60
 msgid "History"
 msgstr "Geçmiş"
 
 #: mygpo/history/templates/episode-history.html:58
 #: mygpo/podcasts/templates/episode.html:58
-#: mygpo/podcasts/templates/podcast-base.html:54
+#: mygpo/podcasts/templates/podcast-base.html:52
 #: mygpo/publisher/templates/publisher/episode.html:40
 #: mygpo/publisher/templates/publisher/podcast.html:39
 #, fuzzy
@@ -654,7 +669,7 @@ msgid "Action"
 msgstr "Eylem"
 
 #: mygpo/history/templates/episode-history.html:86
-#: mygpo/web/templatetags/menu.py:57
+#: mygpo/web/templatetags/menu.py:59
 msgid "Device"
 msgstr "Cihaz"
 
@@ -664,7 +679,7 @@ msgstr "Ekle"
 
 #: mygpo/history/templates/history.html:12
 #: mygpo/history/templates/history.html:15
-#: mygpo/history/templates/podcast-history.html:32
+#: mygpo/history/templates/podcast-history.html:30
 #: mygpo/podcasts/templates/podcast.html:143
 msgid "Subscription History"
 msgstr ""
@@ -698,7 +713,7 @@ msgstr ""
 msgid "Earlier"
 msgstr ""
 
-#: mygpo/history/templates/podcast-history.html:47
+#: mygpo/history/templates/podcast-history.html:45
 msgid "no history yet"
 msgstr ""
 
@@ -776,16 +791,16 @@ msgstr ""
 msgid "%(username)s hasn't created any podcast lists yet."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:103
+#: mygpo/podcastlists/views.py:101
 msgid "You have to specify a title."
 msgstr ""
 
-#: mygpo/podcastlists/views.py:109
+#: mygpo/podcastlists/views.py:107
 #, python-brace-format
 msgid "\"{title}\" is not a valid title"
 msgstr ""
 
-#: mygpo/podcastlists/views.py:162
+#: mygpo/podcastlists/views.py:158
 msgid "Thanks for rating!"
 msgstr ""
 
@@ -829,24 +844,24 @@ msgstr "Favori"
 msgid "Episode History"
 msgstr "Geçmiş"
 
-#: mygpo/podcasts/templates/podcast-base.html:39
+#: mygpo/podcasts/templates/podcast-base.html:37
 #: mygpo/publisher/templates/publisher/episodes.html:23
 #: mygpo/publisher/templates/publisher/podcast.html:27
 msgid "Unnamed Podcast"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:44
+#: mygpo/podcasts/templates/podcast-base.html:42
 #: mygpo/publisher/templates/publisher/podcast.html:29
 msgid "by"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:50
+#: mygpo/podcasts/templates/podcast-base.html:48
 #: mygpo/publisher/templates/publisher/podcast.html:35
 #: mygpo/share/templates/share/favorites.html:29
 msgid "Feed"
 msgstr ""
 
-#: mygpo/podcasts/templates/podcast-base.html:65
+#: mygpo/podcasts/templates/podcast-base.html:63
 #: mygpo/publisher/templates/publisher/podcast.html:44
 msgid "subscribers"
 msgstr ""
@@ -911,9 +926,9 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/advertise.html:9
 #: mygpo/publisher/templates/publisher/info.html:20
-#: mygpo/web/templates/base.html:153 mygpo/web/templates/base.html:180
-#: mygpo/web/templates/home.html:173 mygpo/web/templates/home.html:200
-#: mygpo/web/templatetags/menu.py:76
+#: mygpo/web/templates/base.html:131 mygpo/web/templates/base.html:158
+#: mygpo/web/templates/home.html:174 mygpo/web/templates/home.html:201
+#: mygpo/web/templatetags/menu.py:78
 msgid "Advertise"
 msgstr ""
 
@@ -970,18 +985,6 @@ msgid ""
 "advertisement period."
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/advertise.html:31
-msgid "Start your Advertisement"
-msgstr ""
-
-#: mygpo/publisher/templates/publisher/advertise.html:32
-#, python-format
-msgid ""
-"Contact <a href=\"mailto:stefan@gpodder.net\">stefan@gpodder.net</a> if you "
-"would like to advertise on %(sitename)s or if you have any questions. "
-"Payments are done via PayPal to thp@perli.net."
-msgstr ""
-
 #: mygpo/publisher/templates/publisher/episode.html:31
 msgid "Unnamed Episode"
 msgstr ""
@@ -1003,7 +1006,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episode.html:72
 #: mygpo/publisher/templates/publisher/podcast.html:129
-#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:142
+#: mygpo/web/templates/account.html:65 mygpo/web/templates/account.html:140
 #: mygpo/web/templates/device-edit.html:53
 msgid "Save"
 msgstr ""
@@ -1022,7 +1025,7 @@ msgstr ""
 
 #: mygpo/publisher/templates/publisher/episodes.html:31
 #: mygpo/share/templates/userpage.html:182
-#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:47
+#: mygpo/share/templates/userpage.html:188 mygpo/web/templatetags/menu.py:49
 msgid "Episodes"
 msgstr ""
 
@@ -1106,8 +1109,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/info.html:24
 #, python-format
 msgid ""
-"You can find additional details on the <a href=\"%(advertise-url)s"
-"\">advertisement page</a>."
+"You can find additional details on the <a "
+"href=\"%(advertise-url)s\">advertisement page</a>."
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/info.html:27
@@ -1188,8 +1191,8 @@ msgstr ""
 msgid "Update now"
 msgstr ""
 
-#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:74
-#: mygpo/web/templates/base.html:160 mygpo/web/templates/home.html:180
+#: mygpo/publisher/templates/publisher/podcast.html:117 mygpo/web/forms.py:72
+#: mygpo/web/templates/base.html:138 mygpo/web/templates/home.html:181
 msgid "Twitter"
 msgstr ""
 
@@ -1244,8 +1247,8 @@ msgstr ""
 #: mygpo/publisher/templates/publisher/podcast.html:190
 #, python-format
 msgid ""
-"We found the following license in your podcast: <a href=\"%(license)s\">"
-"%(license)s</a>"
+"We found the following license in your podcast: <a "
+"href=\"%(license)s\">%(license)s</a>"
 msgstr ""
 
 #: mygpo/publisher/templates/publisher/podcast.html:194
@@ -1264,21 +1267,21 @@ msgstr ""
 msgid "Show Group Stats"
 msgstr ""
 
-#: mygpo/publisher/views.py:173
+#: mygpo/publisher/views.py:172
 msgid ""
 "The update has been scheduled. It might take some time until the results are "
 "visible."
 msgstr ""
 
-#: mygpo/publisher/views.py:188 mygpo/users/views/settings.py:115
+#: mygpo/publisher/views.py:187 mygpo/users/views/settings.py:113
 msgid "Data updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:198
+#: mygpo/publisher/views.py:197
 msgid "Publisher token updated"
 msgstr ""
 
-#: mygpo/publisher/views.py:301
+#: mygpo/publisher/views.py:300
 #, python-brace-format
 msgid "Removed slug {slug} from {episode}"
 msgstr ""
@@ -1347,8 +1350,8 @@ msgstr ""
 
 #: mygpo/share/templates/share/overview.html:21
 #: mygpo/web/templates/device.html:19 mygpo/web/templates/privacy.html:25
-#: mygpo/web/templatetags/menu.py:51 mygpo/web/templatetags/menu.py:53
-#: mygpo/web/templatetags/menu.py:67
+#: mygpo/web/templatetags/menu.py:53 mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:69
 msgid "Subscriptions"
 msgstr ""
 
@@ -1363,7 +1366,7 @@ msgid "User Page"
 msgstr ""
 
 #: mygpo/share/templates/share/overview.html:51
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Settings"
 msgstr "Ayarlar"
 
@@ -1476,9 +1479,9 @@ msgstr ""
 #: mygpo/subscriptions/templates/subscriptions.html:42
 #, python-format
 msgid ""
-"You don't have any subscriptions yet. Set up your <a href=\"%(devices)s"
-"\">podcast clients</a> and <a href=\"%(directory)s\">discover interesting "
-"podcasts</a>."
+"You don't have any subscriptions yet. Set up your <a "
+"href=\"%(devices)s\">podcast clients</a> and <a "
+"href=\"%(directory)s\">discover interesting podcasts</a>."
 msgstr ""
 
 #: mygpo/subscriptions/templates/subscriptions.html:63
@@ -1487,22 +1490,22 @@ msgstr ""
 msgid "Download OPML"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:118
+#: mygpo/subscriptions/views.py:116
 #, python-format
 msgid "%(username)s's Podcast Subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:124
+#: mygpo/subscriptions/views.py:122
 #, python-format
 msgid "Recent changes to %(username)s's podcast subscriptions on %(site)s"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:148
+#: mygpo/subscriptions/views.py:146
 #, python-format
 msgid "%(username)s subscribed to %(podcast)s (%(site)s)"
 msgstr ""
 
-#: mygpo/subscriptions/views.py:150
+#: mygpo/subscriptions/views.py:148
 #, python-format
 msgid "%(username)s unsubscribed from %(podcast)s (%(site)s)"
 msgstr ""
@@ -1520,27 +1523,27 @@ msgstr ""
 msgid "No Suggestions Yet"
 msgstr ""
 
-#: mygpo/users/models.py:226
+#: mygpo/users/models.py:232
 msgid "Desktop"
 msgstr ""
 
-#: mygpo/users/models.py:227
+#: mygpo/users/models.py:233
 msgid "Laptop"
 msgstr ""
 
-#: mygpo/users/models.py:228
+#: mygpo/users/models.py:234
 msgid "Cell phone"
 msgstr ""
 
-#: mygpo/users/models.py:229
+#: mygpo/users/models.py:235
 msgid "Server"
 msgstr "Sunucu"
 
-#: mygpo/users/models.py:230
+#: mygpo/users/models.py:236
 msgid "Tablet"
 msgstr ""
 
-#: mygpo/users/models.py:231
+#: mygpo/users/models.py:237
 msgid "Other"
 msgstr "Diğer"
 
@@ -1575,9 +1578,9 @@ msgid "You are already registered."
 msgstr ""
 
 #: mygpo/users/templates/registration/registration_form.html:72
-#: mygpo/web/templates/base.html:52 mygpo/web/templates/home.html:47
-#: mygpo/web/templates/home.html:103 mygpo/web/templates/login.html:48
-#: mygpo/web/templatetags/menu.py:25
+#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
+#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:47
+#: mygpo/web/templatetags/menu.py:26
 msgid "Register"
 msgstr "Kayıt"
 
@@ -1653,129 +1656,119 @@ msgstr ""
 msgid "Your subscription will be updated in a moment."
 msgstr ""
 
-#: mygpo/users/views/registration.py:87
+#: mygpo/users/views/registration.py:90
 msgid "Username or email address already in use"
 msgstr ""
 
-#: mygpo/users/views/registration.py:153
+#: mygpo/users/views/registration.py:155
 msgid "The activation link is either not valid or has already expired."
 msgstr ""
 
-#: mygpo/users/views/registration.py:159
+#: mygpo/users/views/registration.py:163
+msgid ""
+"Your account has been archived. It can't be re-activated automatically. "
+"Please see https://github.com/gpodder/mygpo/issues/866"
+msgstr ""
+
+#: mygpo/users/views/registration.py:170
 msgid "Your user has been activated. You can log in now."
 msgstr ""
 
-#: mygpo/users/views/registration.py:177
+#: mygpo/users/views/registration.py:188
 msgid "Either username or email address are required."
 msgstr ""
 
-#: mygpo/users/views/registration.py:197 mygpo/users/views/user.py:134
+#: mygpo/users/views/registration.py:208 mygpo/users/views/user.py:139
 msgid "User does not exist."
 msgstr ""
 
-#: mygpo/users/views/registration.py:203
+#: mygpo/users/views/registration.py:212
+msgid "Your data has been archived."
+msgstr ""
+
+#: mygpo/users/views/registration.py:221
 msgid "Your account already has been activated. Go ahead and log in."
 msgstr ""
 
-#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:105
+#: mygpo/users/views/settings.py:68 mygpo/users/views/settings.py:103
 msgid "Oops! Something went wrong. Please double-check the data you entered."
 msgstr ""
 
-#: mygpo/users/views/settings.py:127
+#: mygpo/users/views/settings.py:125
 msgid "Your account has been disconnected"
 msgstr ""
 
-#: mygpo/users/views/user.py:73
+#: mygpo/users/views/user.py:72
 #, fuzzy
 msgid "Username missing"
 msgstr "Kullanıcı adı"
 
-#: mygpo/users/views/user.py:78
+#: mygpo/users/views/user.py:77
 #, fuzzy
 msgid "Password missing"
 msgstr "Parola sıfırlama"
 
-#: mygpo/users/views/user.py:85
+#: mygpo/users/views/user.py:84
 msgid "Wrong username or password."
 msgstr "Kullanıcı adı veya parola yanlış "
 
-#: mygpo/users/views/user.py:93 mygpo/users/views/user.py:142
+#: mygpo/users/views/user.py:98 mygpo/users/views/user.py:154
 msgid ""
 "Please activate your account first. We have just re-sent your activation "
 "email"
 msgstr ""
 
-#: mygpo/users/views/user.py:175 mygpo/users/views/user.py:180
-msgid "Login failed."
-msgstr ""
-
-#: mygpo/users/views/user.py:188
-msgid "Login with Google is currently not possible."
-msgstr ""
-
-#: mygpo/users/views/user.py:201
-#, python-brace-format
-msgid ""
-"Your account has been connected with {google}. Open Settings to change this."
-msgstr ""
-
-#: mygpo/users/views/user.py:217
-#, python-format
-msgid ""
-"No account connected with your Google account %s. Please log in to connect."
-msgstr ""
-
-#: mygpo/web/forms.py:22 mygpo/web/forms.py:184
+#: mygpo/web/forms.py:20 mygpo/web/forms.py:182
 msgid "E-Mail address"
 msgstr "E-posta adresi"
 
-#: mygpo/web/forms.py:28
+#: mygpo/web/forms.py:26
 msgid "Current password"
 msgstr "Geçerli parola"
 
-#: mygpo/web/forms.py:36
+#: mygpo/web/forms.py:34
 msgid "New password"
 msgstr "Yeni parola"
 
-#: mygpo/web/forms.py:44
+#: mygpo/web/forms.py:42
 msgid "Confirm password"
 msgstr ""
 
-#: mygpo/web/forms.py:80
+#: mygpo/web/forms.py:78
 msgid "A few words about you"
 msgstr ""
 
-#: mygpo/web/forms.py:94 mygpo/web/templates/devicelist.html:23
+#: mygpo/web/forms.py:92 mygpo/web/templates/devicelist.html:23
 msgid "Name"
 msgstr "Adı"
 
-#: mygpo/web/forms.py:101 mygpo/web/templates/devicelist.html:24
+#: mygpo/web/forms.py:99 mygpo/web/templates/devicelist.html:24
 msgid "Type"
 msgstr "Türü"
 
-#: mygpo/web/forms.py:106 mygpo/web/templates/devicelist.html:25
+#: mygpo/web/forms.py:104 mygpo/web/templates/devicelist.html:25
 msgid "Device ID"
 msgstr "Cihaz Kimliği"
 
-#: mygpo/web/forms.py:110
+#: mygpo/web/forms.py:108
 #, fuzzy
 #| msgid "Device"
 msgid "ID on device"
 msgstr "Cihaz"
 
-#: mygpo/web/forms.py:123
+#: mygpo/web/forms.py:121
 msgid "Share this subscription with other users (public)"
 msgstr ""
 
-#: mygpo/web/forms.py:163
+#: mygpo/web/forms.py:161
 msgid "No device selected"
 msgstr "Cihaz seçilmedi "
 
-#: mygpo/web/forms.py:171
+#: mygpo/web/forms.py:169
 msgid "Please enter your username"
 msgstr "Lütfen kullanıcı adınızı girin"
 
-#: mygpo/web/forms.py:176
+#: mygpo/web/forms.py:174
 msgid "or the email address used while registering"
 msgstr ""
 
@@ -1817,110 +1810,97 @@ msgstr ""
 msgid "Disconnect"
 msgstr ""
 
-#: mygpo/web/templates/account.html:96
-msgid "Connect"
-msgstr ""
-
-#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templates/base.html:40 mygpo/web/templatetags/menu.py:73
 msgid "Account"
 msgstr "Hesap"
 
 #: mygpo/web/templates/base.html:46 mygpo/web/templates/base.html:50
 #: mygpo/web/templates/home.html:41 mygpo/web/templates/home.html:45
-#: mygpo/web/templates/home.html:102 mygpo/web/templates/login.html:8
+#: mygpo/web/templates/home.html:101 mygpo/web/templates/login.html:8
 #: mygpo/web/templates/login.html:11 mygpo/web/templates/login.html:46
 #: mygpo/web/templates/restore_password.html:8
-#: mygpo/web/templatetags/menu.py:24
+#: mygpo/web/templatetags/menu.py:25
 msgid "Login"
 msgstr "Giriş"
 
-#: mygpo/web/templates/base.html:51 mygpo/web/templates/home.html:46
-#: mygpo/web/templates/login.html:47
-msgid "Login with Google"
-msgstr ""
-
-#: mygpo/web/templates/base.html:133 mygpo/web/templates/home.html:153
-#: mygpo/web/templatetags/menu.py:34
+#: mygpo/web/templates/base.html:112 mygpo/web/templates/home.html:155
+#: mygpo/web/templatetags/menu.py:36
 msgid "Discover"
 msgstr ""
 
-#: mygpo/web/templates/base.html:134 mygpo/web/templates/home.html:154
-#: mygpo/web/templatetags/menu.py:36
+#: mygpo/web/templates/base.html:113 mygpo/web/templates/home.html:156
+#: mygpo/web/templatetags/menu.py:38
 msgid "Directory"
 msgstr ""
 
-#: mygpo/web/templates/base.html:142 mygpo/web/templates/home.html:162
+#: mygpo/web/templates/base.html:121 mygpo/web/templates/home.html:164
 msgid "Support"
 msgstr ""
 
-#: mygpo/web/templates/base.html:143 mygpo/web/templates/home.html:163
-#: mygpo/web/templatetags/menu.py:26
+#: mygpo/web/templates/base.html:122 mygpo/web/templates/home.html:165
+#: mygpo/web/templatetags/menu.py:28
 msgid "Docs"
 msgstr ""
 
-#: mygpo/web/templates/base.html:144 mygpo/web/templates/home.html:164
-msgid "Mailing&nbsp;List"
-msgstr ""
-
-#: mygpo/web/templates/base.html:145 mygpo/web/templates/home.html:165
+#: mygpo/web/templates/base.html:123 mygpo/web/templates/home.html:166
 msgid "Questions"
 msgstr ""
 
-#: mygpo/web/templates/base.html:151 mygpo/web/templates/home.html:171
+#: mygpo/web/templates/base.html:129 mygpo/web/templates/home.html:172
 msgid "Support&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:152 mygpo/web/templates/contribute.html:22
-#: mygpo/web/templates/home.html:172
+#: mygpo/web/templates/base.html:130 mygpo/web/templates/contribute.html:22
+#: mygpo/web/templates/home.html:173
 msgid "Donate"
 msgstr ""
 
-#: mygpo/web/templates/base.html:159 mygpo/web/templates/home.html:179
+#: mygpo/web/templates/base.html:137 mygpo/web/templates/home.html:180
 msgid "Follow"
 msgstr ""
 
-#: mygpo/web/templates/base.html:161 mygpo/web/templates/home.html:181
+#: mygpo/web/templates/base.html:139 mygpo/web/templates/home.html:182
 msgid "Blog"
 msgstr ""
 
-#: mygpo/web/templates/base.html:162 mygpo/web/templates/home.html:182
+#: mygpo/web/templates/base.html:140 mygpo/web/templates/home.html:183
 msgid "Blog&nbsp;(RSS)"
 msgstr ""
 
-#: mygpo/web/templates/base.html:168 mygpo/web/templates/home.html:188
+#: mygpo/web/templates/base.html:146 mygpo/web/templates/home.html:189
 msgid "Develop"
 msgstr ""
 
-#: mygpo/web/templates/base.html:169 mygpo/web/templates/home.html:189
+#: mygpo/web/templates/base.html:147 mygpo/web/templates/home.html:190
 msgid "API"
 msgstr ""
 
-#: mygpo/web/templates/base.html:170 mygpo/web/templates/home.html:190
+#: mygpo/web/templates/base.html:148 mygpo/web/templates/home.html:191
 msgid "Libraries"
 msgstr ""
 
-#: mygpo/web/templates/base.html:171 mygpo/web/templates/home.html:191
+#: mygpo/web/templates/base.html:149 mygpo/web/templates/home.html:192
 msgid "Clients"
 msgstr ""
 
-#: mygpo/web/templates/base.html:177 mygpo/web/templates/home.html:197
-#: mygpo/web/templatetags/menu.py:73
+#: mygpo/web/templates/base.html:155 mygpo/web/templates/home.html:198
+#: mygpo/web/templatetags/menu.py:75
 msgid "Publish"
 msgstr ""
 
-#: mygpo/web/templates/base.html:178 mygpo/web/templates/home.html:198
+#: mygpo/web/templates/base.html:156 mygpo/web/templates/home.html:199
 msgid "Get&nbsp;Access"
 msgstr ""
 
-#: mygpo/web/templates/base.html:179 mygpo/web/templates/home.html:199
+#: mygpo/web/templates/base.html:157 mygpo/web/templates/home.html:200
 msgid "Link&nbsp;To&nbsp;Us"
 msgstr ""
 
-#: mygpo/web/templates/base.html:188 mygpo/web/templates/home.html:207
+#: mygpo/web/templates/base.html:166 mygpo/web/templates/home.html:208
 msgid "hosting provided by tornadovps.com"
 msgstr ""
 
-#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:27
+#: mygpo/web/templates/contribute.html:8 mygpo/web/templatetags/menu.py:29
 msgid "Contribute"
 msgstr ""
 
@@ -1944,15 +1924,13 @@ msgid ""
 "If you want to contribute to gpodder.net by writing code, check out the <a "
 "href=\"/developer/\">Development</a> page. We also appreciate contributions "
 "of non-coding work, such as web and interface design, server operations, "
-"testing, etc. If you are interested, join the <a href=\"https://gpodder."
-"github.io/docs/mailing-list.html\">mailing list</a> or the IRC channel "
-"#gpodder on chat.freenode.net."
+"testing, etc."
 msgstr ""
 
 #: mygpo/web/templates/contribute.html:23
 msgid ""
-"If you want to support gpodder.net financially, you can donate via <a href="
-"\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
+"If you want to support gpodder.net financially, you can donate via <a "
+"href=\"https://paypal.me/pools/c/8lxTu5kqTp\">PayPal</a>."
 msgstr ""
 
 #: mygpo/web/templates/csrf.html:8
@@ -1980,7 +1958,7 @@ msgstr "Evet"
 msgid "No"
 msgstr "Hayır"
 
-#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:64
+#: mygpo/web/templates/dashboard.html:14 mygpo/web/templatetags/menu.py:66
 msgid "Overview"
 msgstr ""
 
@@ -1996,18 +1974,17 @@ msgstr ""
 #, python-format
 msgid ""
 "Welcome to %(site)s! If this is your first visit, you should set up your <a "
-"href=\"https://gpoddernet.readthedocs.io/en/latest/user/clients.html"
-"\">podcast client</a> and try to check as many <em>Explore</em> boxes as you "
-"can."
+"href=\"https://gpoddernet.readthedocs.io/en/latest/user/"
+"clients.html\">podcast client</a> and try to check as many <em>Explore</em> "
+"boxes as you can."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:44
 #, python-format
 msgid ""
 "If you have problems, have a look at the <a href=\"%(help)s\">docs</a> or "
-"ask questions on the <a href=\"https://gpodder.github.io/docs/mailing-list."
-"html\">mailing list</a> or <a href=\"https://github.com/gpodder/mygpo/issues"
-"\">forum</a>."
+"ask questions on the <a href=\"https://github.com/gpodder/mygpo/"
+"issues\">issue tracker</a>."
 msgstr ""
 
 #: mygpo/web/templates/dashboard.html:81
@@ -2097,7 +2074,7 @@ msgid "Thanks"
 msgstr "Teşekkürler"
 
 #: mygpo/web/templates/developer.html:8 mygpo/web/templates/developer.html:11
-#: mygpo/web/templatetags/menu.py:28
+#: mygpo/web/templatetags/menu.py:30
 msgid "Development"
 msgstr ""
 
@@ -2216,9 +2193,9 @@ msgstr ""
 
 #: mygpo/web/templates/devicelist.html:53
 msgid ""
-"You don't have any devices yet. Go to the <a href=\"https://gpoddernet."
-"readthedocs.io/en/latest/user/clients.html\">clients</a> page to learn how "
-"to set up your client applications."
+"You don't have any devices yet. Go to the <a href=\"https://"
+"gpoddernet.readthedocs.io/en/latest/user/clients.html\">clients</a> page to "
+"learn how to set up your client applications."
 msgstr ""
 
 #: mygpo/web/templates/devicelist.html:74
@@ -2234,7 +2211,7 @@ msgid "Delete Permanently"
 msgstr ""
 
 #: mygpo/web/templates/favorites.html:10 mygpo/web/templates/favorites.html:13
-#: mygpo/web/templatetags/menu.py:54 mygpo/web/templatetags/menu.py:65
+#: mygpo/web/templatetags/menu.py:56 mygpo/web/templatetags/menu.py:67
 msgid "Favorite Episodes"
 msgstr ""
 
@@ -2258,15 +2235,15 @@ msgid ""
 msgstr ""
 
 #: mygpo/web/templates/mytags.html:11 mygpo/web/templates/mytags.html:14
-#: mygpo/web/templatetags/menu.py:55
+#: mygpo/web/templatetags/menu.py:57
 msgid "My Tags"
 msgstr "Etiketlerim"
 
 #: mygpo/web/templates/mytags.html:41
 #, python-format
 msgid ""
-"You didn't tag any podcasts yet. Go to your <a href=\"%(subscriptions-url)s"
-"\">subscriptions</a> and tag some."
+"You didn't tag any podcasts yet. Go to your <a "
+"href=\"%(subscriptions-url)s\">subscriptions</a> and tag some."
 msgstr ""
 
 #: mygpo/web/templates/password_reset.html:4
@@ -2280,8 +2257,8 @@ msgstr ""
 #: mygpo/web/templates/password_reset.html:13
 #, python-format
 msgid ""
-"You should have received an mail with your new password. Please <a href="
-"\"%(login-url)s\">log in</a> now."
+"You should have received an mail with your new password. Please <a "
+"href=\"%(login-url)s\">log in</a> now."
 msgstr ""
 
 #: mygpo/web/templates/password_reset_failed.html:4
@@ -2337,7 +2314,7 @@ msgstr ""
 msgid "Make Public"
 msgstr ""
 
-#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:29
+#: mygpo/web/templates/privacy_policy.html:8 mygpo/web/templatetags/menu.py:31
 msgid "Privacy Policy"
 msgstr ""
 
@@ -2369,6 +2346,15 @@ msgid ""
 "Because we display names after we have fetched the information from the feed "
 "-- and this may take some time. Until this is completed, the podcast will "
 "simply be called this way."
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:8
+#: mygpo/web/templates/user_archived.html:11
+msgid "Archived User"
+msgstr ""
+
+#: mygpo/web/templates/user_archived.html:15
+msgid "Due to over a year inactivity your account has been archived."
 msgstr ""
 
 #: mygpo/web/templates/user_subscriptions.html:14
@@ -2516,47 +2502,51 @@ msgstr ""
 msgid "Unknown Episode"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:23 mygpo/web/templatetags/menu.py:75
+#: mygpo/web/templatetags/menu.py:24 mygpo/web/templatetags/menu.py:77
 msgid "Home"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:30
+#: mygpo/web/templatetags/menu.py:27
+msgid "Archived"
+msgstr ""
+
+#: mygpo/web/templatetags/menu.py:32
 msgid "Help"
 msgstr "Yardım"
 
-#: mygpo/web/templatetags/menu.py:41
+#: mygpo/web/templatetags/menu.py:43
 msgid "User subscriptions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:42
+#: mygpo/web/templatetags/menu.py:44
 msgid "Suggestions"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:43
+#: mygpo/web/templatetags/menu.py:45
 msgid "Features"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:45
+#: mygpo/web/templatetags/menu.py:47
 msgid "Toplists"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:56
+#: mygpo/web/templatetags/menu.py:58
 msgid "Devices"
 msgstr "Cihazlar"
 
-#: mygpo/web/templatetags/menu.py:62
+#: mygpo/web/templatetags/menu.py:64
 msgid "Community"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:66
+#: mygpo/web/templatetags/menu.py:68
 msgid "My Userpage"
 msgstr ""
 
-#: mygpo/web/templatetags/menu.py:71
+#: mygpo/web/templatetags/menu.py:73
 msgid "Privacy"
 msgstr "Gizlilik"
 
-#: mygpo/web/templatetags/menu.py:77
+#: mygpo/web/templatetags/menu.py:79
 msgid "Link to gpodder.net"
 msgstr ""
 
@@ -2570,25 +2560,25 @@ msgstr ""
 msgid "{m}m {s}s"
 msgstr ""
 
-#: mygpo/web/utils.py:297
+#: mygpo/web/utils.py:294
 #, python-format
 msgid "%(weeks)d week"
 msgid_plural "%(weeks)d weeks"
 msgstr[0] ""
 
-#: mygpo/web/utils.py:301
+#: mygpo/web/utils.py:298
 #, python-format
 msgid "%(days)d day"
 msgid_plural "%(days)d days"
 msgstr[0] ""
 
-#: mygpo/web/utils.py:305
+#: mygpo/web/utils.py:302
 #, python-format
 msgid "%(hours)d hour"
 msgid_plural "%(hours)d hours"
 msgstr[0] ""
 
-#: mygpo/web/views.py:149
+#: mygpo/web/views.py:131
 msgid "another site"
 msgstr ""
 

--- a/mygpo/web/templates/base.html
+++ b/mygpo/web/templates/base.html
@@ -120,7 +120,6 @@
                             <ul>
                                 <li><strong>{% trans "Support" %}</strong></li>
                                 <li><a href="{% url "help" %}">{% trans "Docs" %}</a></li>
-                                <li><a href="https://gpodder.github.io/docs/mailing-list.html">{% trans "Mailing&nbsp;List" %}</a></li>
                                 <li><a href="https://github.com/gpodder/mygpo/issues">{%trans "Questions" %}</a></li>
                             </ul>
                         </div>

--- a/mygpo/web/templates/contribute.html
+++ b/mygpo/web/templates/contribute.html
@@ -16,7 +16,7 @@
   <p>{% blocktrans %}gpodder.net is run as a hobby project without continuous funding for servers, storage and bandwidth. We rely on contributors and donations to keep the site running and improve it constantly.{% endblocktrans %}</p>
 
   <h2>{% trans "Work" %}</h2>
-  <p>{% blocktrans %}If you want to contribute to gpodder.net by writing code, check out the <a href="/developer/">Development</a> page. We also appreciate contributions of non-coding work, such as web and interface design, server operations, testing, etc. If you are interested, join the <a href="https://gpodder.github.io/docs/mailing-list.html">mailing list</a> or the IRC channel #gpodder on chat.freenode.net.{% endblocktrans %}</p>
+  <p>{% blocktrans %}If you want to contribute to gpodder.net by writing code, check out the <a href="/developer/">Development</a> page. We also appreciate contributions of non-coding work, such as web and interface design, server operations, testing, etc.{% endblocktrans %}</p>
 
 
   <h2>{% trans "Donate" %}</h2>

--- a/mygpo/web/templates/dashboard.html
+++ b/mygpo/web/templates/dashboard.html
@@ -41,7 +41,7 @@
 
     <p>
      {% url "help" as help %}
-     {% blocktrans %}If you have problems, have a look at the <a href="{{ help }}">docs</a> or ask questions on the <a href="https://gpodder.github.io/docs/mailing-list.html">mailing list</a> or <a href="https://github.com/gpodder/mygpo/issues">forum</a>.{% endblocktrans %}
+     {% blocktrans %}If you have problems, have a look at the <a href="{{ help }}">docs</a> or ask questions on the <a href="https://github.com/gpodder/mygpo/issues">forum</a>.{% endblocktrans %}
     </p>
 
    {% endif %}

--- a/mygpo/web/templates/dashboard.html
+++ b/mygpo/web/templates/dashboard.html
@@ -41,7 +41,7 @@
 
     <p>
      {% url "help" as help %}
-     {% blocktrans %}If you have problems, have a look at the <a href="{{ help }}">docs</a> or ask questions on the <a href="https://github.com/gpodder/mygpo/issues">forum</a>.{% endblocktrans %}
+     {% blocktrans %}If you have problems, have a look at the <a href="{{ help }}">docs</a> or ask questions on the <a href="https://github.com/gpodder/mygpo/issues">issue tracker</a>.{% endblocktrans %}
     </p>
 
    {% endif %}

--- a/mygpo/web/templates/home.html
+++ b/mygpo/web/templates/home.html
@@ -163,7 +163,6 @@ and DB migration was done by June 2025. Web app is migrated, but still the old V
                             <ul>
                                 <li><strong>{% trans "Support" %}</strong></li>
                                 <li><a href="{% url "help" %}">{% trans "Docs" %}</a></li>
-                                <li><a href="https://gpodder.github.io/docs/mailing-list.html">{% trans "Mailing&nbsp;List" %}</a></li>
                                 <li><a href="https://github.com/gpodder/mygpo/issues">{%trans "Questions" %}</a></li>
                             </ul>
                         </div>


### PR DESCRIPTION
It's mostly used for client development, not mygpo, and to avoid spam from automated agents, let's not advertise the mailing list.